### PR TITLE
Add database updater

### DIFF
--- a/database_updates.php
+++ b/database_updates.php
@@ -1,0 +1,48 @@
+<?php
+/*
+ * ITFlow
+ * This file defines the SQL queries required to update the database to the "latest" database version
+ * It is used in conjunction with database_version.php
+ */
+
+// Check if our database versions are defined
+// If undefined, the file is probably being accessed directly rather than called via post.php?update_db
+if(!defined("LATEST_DATABASE_VERSION") || !defined("CURRENT_DATABASE_VERSION") || !isset($mysqli)){
+  echo "Cannot access this file directly.";
+  exit();
+}
+
+
+// Check if we need an update
+if(LATEST_DATABASE_VERSION > CURRENT_DATABASE_VERSION){
+
+  // We need updates!
+
+
+  if(CURRENT_DATABASE_VERSION == '0.0.1'){
+    // Insert queries here required to update to DB version 0.0.2
+    // mysqli_query($mysqli, "ALTER TABLE .....");
+
+
+    // Then, update the database to the next sequential version
+    //mysqli_query($mysqli, "UPDATE settings SET config_current_database_version = '0.0.2' WHERE company_id = '1'");
+
+  }
+
+
+  if(CURRENT_DATABASE_VERSION == '0.0.2'){
+    // Insert queries here required to update to DB version 0.0.3
+    // mysqli_query($mysqli, "ALTER TABLE .....");
+
+
+    // Then, update the database to the next sequential version
+    //mysqli_query($mysqli, "UPDATE settings SET config_current_database_version = '0.0.3' WHERE company_id = '1'");
+
+  }
+
+  // etc
+
+}
+else{
+  // Up-to-date
+}

--- a/database_version.php
+++ b/database_version.php
@@ -1,0 +1,8 @@
+<?php
+/*
+ * ITFlow
+ * This file defines the current "latest" database version
+ * It is used in conjunction with database_updates.php
+ */
+
+DEFINE("LATEST_DATABASE_VERSION", "0.0.1");

--- a/db.sql
+++ b/db.sql
@@ -1086,6 +1086,7 @@ DROP TABLE IF EXISTS `settings`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `settings` (
   `company_id` int(11) NOT NULL,
+  `config_current_database_version` varchar(10) NOT NULL,
   `config_base_url` varchar(200) DEFAULT NULL,
   `config_smtp_host` varchar(200) DEFAULT NULL,
   `config_smtp_port` int(5) DEFAULT NULL,

--- a/get_settings.php
+++ b/get_settings.php
@@ -7,6 +7,9 @@ $row = mysqli_fetch_array($sql_settings);
 // General
 $config_base_url = $row['config_base_url'];
 
+// Database version
+DEFINE("CURRENT_DATABASE_VERSION", $row['config_current_database_version']);
+
 // Mesh Central
 $config_meshcentral_uri = $row['config_meshcentral_uri'];
 $config_meshcentral_user = $row['config_meshcentral_user'];

--- a/post.php
+++ b/post.php
@@ -1278,23 +1278,11 @@ if(isset($_GET['update_db'])){
       exit();
     }
 
-    //Alter SQL Structure
+    // Get the current version
+    require_once ('database_version.php');
 
-    //Put ID Here
-    //mysqli_query($mysqli,"ALTER TABLE logs ADD log_ip VARCHAR(200) NULL AFTER log_description");
-    //mysqli_query($mysqli,"ALTER TABLE logs ADD log_user_agent VARCHAR(250) NULL AFTER log_ip");
-
-    //85cdc42d0f15e36de5cab00d7f3c799a056e85ef
-    //mysqli_query($mysqli,"ALTER TABLE assets ADD asset_install_date DATE NULL AFTER asset_warranty_expire");
-
-    //c88e6b851aadfbde173f7cfe7155dd1ed31adece
-    //mysqli_query($mysqli,"ALTER TABLE settings DROP config_enable_alert_low_balance");
-    //mysqli_query($mysqli,"ALTER TABLE settings DROP config_account_balance_threshold");
-    //mysqli_query($mysqli,"ALTER TABLE clients DROP client_support");
-    //mysqli_query($mysqli,"ALTER TABLE tags DROP tag_archived_at");
-
-    //Update 2
-    //mysqli_query($mysqli,"ALTER TABLE tags ADD tag_type INT(11) NOT NULL AFTER tag_name");
+    // Perform upgrades, if required
+    require_once ('database_updates.php');
 
     //Logging
     mysqli_query($mysqli,"INSERT INTO logs SET log_type = 'Settings', log_action = 'Update', log_description = '$session_name updated the database structure', log_ip = '$session_ip', log_user_agent = '$session_user_agent', log_created_at = NOW(), log_user_id = $session_user_id, company_id = $session_company_id");

--- a/settings-update.php
+++ b/settings-update.php
@@ -1,4 +1,7 @@
-<?php include("inc_all_admin.php"); ?>
+<?php
+include("inc_all_admin.php");
+include("database_version.php");
+?>
 
 <?php
 
@@ -8,81 +11,68 @@ $latest_version = exec("gitrev-parse origin/master");
 $current_version = exec("git rev-parse HEAD");
 
 if($current_version == $latest_version){
-    $update_message = "No Updates available";
+  $update_message = "No Updates available";
 }else{
-    $update_message = "New Updates are Available [$latest_version]";
+  $update_message = "New Updates are Available [$latest_version]";
 }
 
 $git_log = shell_exec("git log master..origin/master --pretty=format:'<tr><td>%h</td><td>%ar</td><td>%s</td></tr>'");
 
 ?>
 
-<div class="card card-dark">
+  <div class="card card-dark">
     <div class="card-header">
-        <h3 class="card-title"><i class="fas fa-fw fa-arrow-alt-circle-up"></i> Update</h3>
+      <h3 class="card-title"><i class="fas fa-fw fa-arrow-alt-circle-up"></i> Update</h3>
     </div>
     <div class="card-body">
-        <center>
-            <?php if(!empty($git_log)){ ?>
-                <a class="btn btn-primary btn-lg my-4" href="post.php?update"><i class="fas fa-fw fa-4x fa-arrow-alt-circle-up mb-1"></i><h5>Update App</h5></a>
-                <?php
-            }else{
-                ?>
-                <a class="btn btn-dark btn-lg my-4" href="post.php?update_db"><i class="fas fa-fw fa-4x fa-arrow-alt-circle-up mb-1"></i><h5>Update Database</h5></a>
-                <h3 class="text-success"><i class="fas fa-check-square"></i> Latest version</h3>
-                <small class="text-secondary"><?php echo $current_version; ?></small>
-                <?php
-            }
-            ?>
-        </center>
-
-        <?php
-        if(!empty($git_log)){
-            ?>
-            <table class="table ">
-                <thead>
-                <tr>
-                    <th>Commit</th>
-                    <th>When</th>
-                    <th>Description</th>
-                </tr>
-                </thead>
-                <tbody>
-                <?php
-                echo $git_log;
-                ?>
-                </tbody>
-            </table>
-            <?php
+      <center>
+        <div class="alert alert-warning" role="alert">
+          <strong>Ensure you have a current app & database backup before updating!</strong>
+        </div>
+        <?php if(!empty($git_log)){ ?>
+          <a class="btn btn-primary btn-lg my-4" href="post.php?update"><i class="fas fa-fw fa-4x fa-arrow-alt-circle-up mb-1"></i><h5>Update App</h5></a>
+          <?php
+        }else{
+            if(LATEST_DATABASE_VERSION > CURRENT_DATABASE_VERSION){ ?>
+              <a class="btn btn-dark btn-lg my-4" href="post.php?update_db"><i class="fas fa-fw fa-4x fa-arrow-alt-circle-up mb-1"></i><h5>Update Database</h5></a>
+              <br>
+              <small class="text-secondary">Current DB Version: <?php echo CURRENT_DATABASE_VERSION; ?></small>
+              <br>
+              <small class="text-secondary">Latest DB Version: <?php echo LATEST_DATABASE_VERSION; ?></small>
+            <?php }
+            else{ ?>
+              <h3 class="text-success"><i class="fas fa-check-square"></i> Latest version!</h3>
+              <small class="text-secondary">Current DB Version: <?php echo CURRENT_DATABASE_VERSION; ?></small>
+            <?php } ?>
+          <?php
         }
-
-        // Display a diff between the current DB structure and the latest DB structure, *NIX only
-        if((strtoupper(substr(PHP_OS, 0, 3)) !== 'WIN')){
-
-            $tmp_path = sys_get_temp_dir();
-
-            // Get DB structure as it is
-            exec("mysqldump --user=$dbusername --password=$dbpassword --skip-extended-insert -d --no-data $database | sed 's/ AUTO_INCREMENT=[0-9]*//g' | egrep -v 'MariaDB dump|Host:|Server version|Dump completed' > $tmp_path/current-structure.sql");
-
-            // Get the new structure from db.sql
-            exec("egrep -v 'MariaDB dump|Host:|Server version|Dump completed' db.sql > $tmp_path/new-structure.sql");
-
-            // Compare
-            exec("diff $tmp_path/current-structure.sql $tmp_path/new-structure.sql > $tmp_path/diff.txt");
-            $diff = file_get_contents("$tmp_path/diff.txt");
-
-            // Display, if there is a difference
-            if(!empty($diff)){
-                echo "<br><br><h2>Diff between your database structure and db.sql</h2>";
-                echo "<div style=\"white-space: pre-line\"> $diff </div>";
-            }
-
-        }
-
         ?>
+      </center>
+
+      <?php
+      if(!empty($git_log)){
+        ?>
+        <table class="table ">
+          <thead>
+          <tr>
+            <th>Commit</th>
+            <th>When</th>
+            <th>Description</th>
+          </tr>
+          </thead>
+          <tbody>
+          <?php
+          echo $git_log;
+          ?>
+          </tbody>
+        </table>
+        <?php
+      }
+
+      ?>
 
     </div>
-</div>
+  </div>
 
 <?php
 

--- a/setup.php
+++ b/setup.php
@@ -3,7 +3,9 @@
 if(file_exists("config.php")){
   include("config.php");
 }
+
 include("functions.php");
+include("database_version.php");
 
 if(!isset($config_enable_setup)){
   $config_enable_setup = 1;
@@ -979,7 +981,8 @@ if(isset($_POST['add_company_settings'])){
   //Set User Company Permissions
   mysqli_query($mysqli,"INSERT INTO user_companies SET user_id = $user_id, company_id = $company_id");
 
-  mysqli_query($mysqli,"INSERT INTO settings SET company_id = $company_id, config_invoice_prefix = 'INV-', config_invoice_next_number = 1, config_recurring_prefix = 'REC-', config_recurring_next_number = 1, config_invoice_overdue_reminders = '1,3,7', config_quote_prefix = 'QUO-', config_quote_next_number = 1, config_recurring_auto_send_invoice = 1, config_default_net_terms = 7, config_send_invoice_reminders = 1, config_enable_cron = 0, config_ticket_next_number = 1, config_base_url = '$config_base_url'");
+  $latest_database_version = LATEST_DATABASE_VERSION;
+  mysqli_query($mysqli,"INSERT INTO settings SET company_id = $company_id, config_current_database_version = '$latest_database_version',  config_invoice_prefix = 'INV-', config_invoice_next_number = 1, config_recurring_prefix = 'REC-', config_recurring_next_number = 1, config_invoice_overdue_reminders = '1,3,7', config_quote_prefix = 'QUO-', config_quote_next_number = 1, config_recurring_auto_send_invoice = 1, config_default_net_terms = 7, config_send_invoice_reminders = 1, config_enable_cron = 0, config_ticket_next_number = 1, config_base_url = '$config_base_url'");
 
   //Create Some Data
 


### PR DESCRIPTION
This PR adds a database updater!

`settings-update.php` first prompts for git to be fully up-to-date, as it does already.

Once git/files are fully updated, it compares the current database version stored in the settings table against the one stored in `database_version.php`. If there is an update, the user is prompted to update. 

`post.php` with GET param `update_db` calls `database_updates.php` which will incrementally upgrade the database structure.

In order to add this to existing installs, run the following SQL queries:
```
ALTER TABLE `settings` ADD `config_current_database_version` VARCHAR(10) NOT NULL AFTER `company_id`;
UPDATE `settings` SET `config_current_database_version` = '0.0.1' WHERE `settings`.`company_id` = 1; 
```

---

### Going Forward:
Anytime we change the database schema we need to:
- Update `db.sql` (as before)
- Increment the `LATEST_DATABASE_VERSION` constant in `database_version.php`
- Add the appropriate SQL commands (in the right order!) to `database_updates.php` 
  - Ensure that the final query sets the `config_current_database_version` value to the latest version

This should help people enjoy a seamless upgrade experience :)