### PR TITLE
Default client logs to sort same as main logs

### DIFF
--- a/client_logs.php
+++ b/client_logs.php
@@ -32,8 +32,8 @@ if(isset($_GET['o'])){
     $disp = "ASC";
   }
 }else{
-  $o = "ASC";
-  $disp = "DESC";
+  $o = "DESC";
+  $disp = "ASC";
 }
 
 //Rebuild URL


### PR DESCRIPTION
Sort the logs correctly by default, so you see the latest entries first