### PR TITLE
Role enforcement

### DIFF
--- a/clients.php
+++ b/clients.php
@@ -320,7 +320,7 @@ $num_rows = mysqli_fetch_row(mysqli_query($mysqli,"SELECT FOUND_ROWS()"));
             <?php } ?>
 
             <!-- Show actions for Admin role only -->
-            <?php //if($session_user_role == 3) { ?>
+            <?php if($session_user_role == 3) { ?>
               <td>
                 <div class="dropdown dropleft text-center">
                   <button class="btn btn-secondary btn-sm" type="button" data-toggle="dropdown">
@@ -335,7 +335,7 @@ $num_rows = mysqli_fetch_row(mysqli_query($mysqli,"SELECT FOUND_ROWS()"));
                   </div>
                 </div>
               </td>
-            <?php //} ?>
+            <?php } ?>
           </tr>
 
           <?php

--- a/clients.php
+++ b/clients.php
@@ -320,7 +320,7 @@ $num_rows = mysqli_fetch_row(mysqli_query($mysqli,"SELECT FOUND_ROWS()"));
             <?php } ?>
 
             <!-- Show actions for Admin role only -->
-            <?php if($session_user_role == 3) { ?>
+            <?php if ($session_user_role == 3) { ?>
               <td>
                 <div class="dropdown dropleft text-center">
                   <button class="btn btn-secondary btn-sm" type="button" data-toggle="dropdown">

--- a/dashboard_financial.php
+++ b/dashboard_financial.php
@@ -1,6 +1,17 @@
 <?php include("inc_all.php"); ?>
 
-<?php 
+<?php
+
+// Quick fix to prevent non-admins (i.e. techs) seeing financials - redirect to client list
+//  To be removed when we have a proper technical dashboard for techs
+if ($_SESSION['user_role'] != 3) { ?>
+  <script type="text/javascript">
+      window.location.href = 'clients.php';
+  </script>
+<?php
+  exit();
+}
+
 
 function roundUpToNearestMultiple($n, $increment = 1000)
 {


### PR DESCRIPTION
- Quick redirect fix for stopping techs seeing the financial dashboard. 
  - I know we eventually have plans to create more dashboards, so maybe we can show them automatically based on role?
  - This solves #497
- Remove the actions button on the clients.php page for techs/accountants (they weren't able to make edits anyway)