### PR TITLE
Fix date field issue

### DIFF
--- a/api_key_add_modal.php
+++ b/api_key_add_modal.php
@@ -47,7 +47,7 @@ $key = keygen();
               <div class="input-group-prepend">
                 <span class="input-group-text"><i class="fa fa-fw fa-calendar"></i></span>
               </div>
-              <input type="date" class="form-control" name="expire" required>
+              <input type="date" class="form-control" name="expire" max="2999-12-31" required>
             </div>
           </div>
 

--- a/assets.php
+++ b/assets.php
@@ -57,13 +57,13 @@ $num_rows = mysqli_fetch_row(mysqli_query($mysqli,"SELECT FOUND_ROWS()"));
           <div class="col-md-2">
             <div class="form-group">
               <label>Date From</label>
-              <input type="date" class="form-control" name="dtf" value="<?php echo $dtf; ?>">
+              <input type="date" class="form-control" name="dtf" max="2999-12-31" value="<?php echo $dtf; ?>">
             </div>
           </div>
           <div class="col-md-2">
             <div class="form-group">
               <label>Date To</label>
-              <input type="date" class="form-control" name="dtt" value="<?php echo $dtt; ?>">
+              <input type="date" class="form-control" name="dtt" max="2999-12-31" value="<?php echo $dtt; ?>">
             </div>
           </div>
         </div>    

--- a/client_asset_add_modal.php
+++ b/client_asset_add_modal.php
@@ -257,7 +257,7 @@
                   <div class="input-group-prepend">
                     <span class="input-group-text"><i class="fa fa-fw fa-calendar"></i></span>
                   </div>
-                  <input type="date" class="form-control" name="install_date">
+                  <input type="date" class="form-control" name="install_date" max="2999-12-31">
                 </div>
               </div>
 
@@ -268,7 +268,7 @@
                   <div class="input-group-prepend">
                     <span class="input-group-text"><i class="fa fa-fw fa-shopping-cart"></i></span>
                   </div>
-                  <input type="date" class="form-control" name="purchase_date">
+                  <input type="date" class="form-control" name="purchase_date" max="2999-12-31">
                 </div>
               </div>
               <div class="form-group">
@@ -277,7 +277,7 @@
                   <div class="input-group-prepend">
                     <span class="input-group-text"><i class="fa fa-fw fa-calendar"></i></span>
                   </div>
-                  <input type="date" class="form-control" name="warranty_expire">
+                  <input type="date" class="form-control" name="warranty_expire" max="2999-12-31">
                 </div>
               </div>
               <?php } ?>

--- a/client_asset_copy_modal.php
+++ b/client_asset_copy_modal.php
@@ -254,7 +254,7 @@
                   <div class="input-group-prepend">
                     <span class="input-group-text"><i class="fa fa-fw fa-calendar"></i></span>
                   </div>
-                  <input type="date" class="form-control" name="install_date" value="<?php echo $asset_install_date; ?>">
+                  <input type="date" class="form-control" name="install_date" max="2999-12-31" value="<?php echo $asset_install_date; ?>">
                 </div>
               </div>
 
@@ -265,7 +265,7 @@
                   <div class="input-group-prepend">
                     <span class="input-group-text"><i class="fa fa-fw fa-shopping-cart"></i></span>
                   </div>
-                  <input type="date" class="form-control" name="purchase_date" value="<?php echo $asset_purchase_date; ?>">
+                  <input type="date" class="form-control" name="purchase_date" max="2999-12-31" value="<?php echo $asset_purchase_date; ?>">
                 </div>
               </div>
               
@@ -275,7 +275,7 @@
                   <div class="input-group-prepend">
                     <span class="input-group-text"><i class="fa fa-fw fa-calendar"></i></span>
                   </div>
-                  <input type="date" class="form-control" name="warranty_expire" value="<?php echo $asset_warranty_expire; ?>">
+                  <input type="date" class="form-control" name="warranty_expire" max="2999-12-31" value="<?php echo $asset_warranty_expire; ?>">
                 </div>
               </div>
               <?php } ?>

--- a/client_asset_edit_modal.php
+++ b/client_asset_edit_modal.php
@@ -255,7 +255,7 @@
                   <div class="input-group-prepend">
                     <span class="input-group-text"><i class="fa fa-fw fa-calendar"></i></span>
                   </div>
-                  <input type="date" class="form-control" name="install_date" value="<?php echo $asset_install_date; ?>">
+                  <input type="date" class="form-control" name="install_date" max="2999-12-31" value="<?php echo $asset_install_date; ?>">
                 </div>
               </div>
 
@@ -266,7 +266,7 @@
                   <div class="input-group-prepend">
                     <span class="input-group-text"><i class="fa fa-fw fa-shopping-cart"></i></span>
                   </div>
-                  <input type="date" class="form-control" name="purchase_date" value="<?php echo $asset_purchase_date; ?>">
+                  <input type="date" class="form-control" name="purchase_date" max="2999-12-31" value="<?php echo $asset_purchase_date; ?>">
                 </div>
               </div>
               
@@ -276,7 +276,7 @@
                   <div class="input-group-prepend">
                     <span class="input-group-text"><i class="fa fa-fw fa-calendar"></i></span>
                   </div>
-                  <input type="date" class="form-control" name="warranty_expire" value="<?php echo $asset_warranty_expire; ?>">
+                  <input type="date" class="form-control" name="warranty_expire" max="2999-12-31" value="<?php echo $asset_warranty_expire; ?>">
                 </div>
               </div>
               <?php } ?>

--- a/client_certificate_add_modal.php
+++ b/client_certificate_add_modal.php
@@ -50,7 +50,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text"><i class="fa fa-fw fa-calendar"></i></span>
                             </div>
-                            <input type="date" class="form-control" name="expire" id="expire">
+                            <input type="date" class="form-control" name="expire" id="expire" max="2999-12-31">
                         </div>
                     </div>
 

--- a/client_certificate_edit_modal.php
+++ b/client_certificate_edit_modal.php
@@ -50,7 +50,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text"><i class="fa fa-fw fa-calendar"></i></span>
                             </div>
-                            <input type="date" class="form-control" id="editExpire" name="expire"  value="">
+                            <input type="date" class="form-control" id="editExpire" name="expire" max="2999-12-31" value="">
                         </div>
                     </div>
 

--- a/client_domain_add_modal.php
+++ b/client_domain_add_modal.php
@@ -75,7 +75,7 @@
               <div class="input-group-prepend">
                 <span class="input-group-text"><i class="fa fa-fw fa-calendar"></i></span>
               </div>
-              <input type="date" class="form-control" name="expire"> 
+              <input type="date" class="form-control" name="expire" max="2999-12-31">
             </div>
           </div>
 

--- a/client_domain_edit_modal.php
+++ b/client_domain_edit_modal.php
@@ -64,7 +64,7 @@
                   <div class="input-group-prepend">
                     <span class="input-group-text"><i class="fa fa-fw fa-calendar"></i></span>
                   </div>
-                  <input type="date" class="form-control" id="editExpire" name="expire">
+                  <input type="date" class="form-control" id="editExpire" name="expire" max="2999-12-31">
                 </div>
               </div>
 

--- a/client_software_add_modal.php
+++ b/client_software_add_modal.php
@@ -111,7 +111,7 @@
                   <div class="input-group-prepend">
                     <span class="input-group-text"><i class="fa fa-fw fa-calendar"></i></span>
                   </div>
-                  <input type="date" class="form-control" name="purchase"> 
+                  <input type="date" class="form-control" name="purchase" max="2999-12-31">
                 </div>
               </div>
 
@@ -121,7 +121,7 @@
                   <div class="input-group-prepend">
                     <span class="input-group-text"><i class="fa fa-fw fa-calendar"></i></span>
                   </div>
-                  <input type="date" class="form-control" name="expire"> 
+                  <input type="date" class="form-control" name="expire" max="2999-12-31">
                 </div>
               </div>
 

--- a/client_software_edit_modal.php
+++ b/client_software_edit_modal.php
@@ -111,7 +111,7 @@
                   <div class="input-group-prepend">
                     <span class="input-group-text"><i class="fa fa-fw fa-calendar"></i></span>
                   </div>
-                  <input type="date" class="form-control" name="purchase" value="<?php echo $software_purchase; ?>"> 
+                  <input type="date" class="form-control" name="purchase" max="2999-12-31" value="<?php echo $software_purchase; ?>">
                 </div>
               </div>
 
@@ -121,7 +121,7 @@
                   <div class="input-group-prepend">
                     <span class="input-group-text"><i class="fa fa-fw fa-calendar"></i></span>
                   </div>
-                  <input type="date" class="form-control" name="expire" value="<?php echo $software_expire; ?>"> 
+                  <input type="date" class="form-control" name="expire" max="2999-12-31" value="<?php echo $software_expire; ?>">
                 </div>
               </div>
 

--- a/clients.php
+++ b/clients.php
@@ -148,13 +148,13 @@ $num_rows = mysqli_fetch_row(mysqli_query($mysqli,"SELECT FOUND_ROWS()"));
           <div class="col-md-2">
             <div class="form-group">
               <label>Date From</label>
-              <input type="date" class="form-control" name="date_from" value="<?php echo $date_from; ?>">
+              <input type="date" class="form-control" name="date_from" max="2999-12-31" value="<?php echo $date_from; ?>">
             </div>
           </div>
           <div class="col-md-2">
             <div class="form-group">
               <label>Date To</label>
-              <input type="date" class="form-control" name="date_to" value="<?php echo $date_to; ?>">
+              <input type="date" class="form-control" name="date_to" max="2999-12-31" value="<?php echo $date_to; ?>">
             </div>
           </div>
         </div>    

--- a/expense_add_modal.php
+++ b/expense_add_modal.php
@@ -17,7 +17,7 @@
                 <div class="input-group-prepend">
                   <span class="input-group-text"><i class="fa fa-fw fa-calendar"></i></span>
                 </div>
-                <input type="date" class="form-control" name="date" value="<?php echo date("Y-m-d"); ?>" required>
+                <input type="date" class="form-control" name="date" max="2999-12-31" value="<?php echo date("Y-m-d"); ?>" required>
               </div>
             </div>
 

--- a/expense_copy_modal.php
+++ b/expense_copy_modal.php
@@ -17,7 +17,7 @@
                 <div class="input-group-prepend">
                   <span class="input-group-text"><i class="fa fa-fw fa-calendar"></i></span>
                 </div>
-                <input type="date" class="form-control" name="date" value="<?php echo date("Y-m-d"); ?>" required>
+                <input type="date" class="form-control" name="date" max="2999-12-31" value="<?php echo date("Y-m-d"); ?>" required>
               </div>
             </div>
             

--- a/expense_edit_modal.php
+++ b/expense_edit_modal.php
@@ -20,7 +20,7 @@
                 <div class="input-group-prepend">
                   <span class="input-group-text"><i class="fa fa-fw fa-calendar"></i></span>
                 </div>
-                <input type="date" class="form-control" name="date" value="<?php echo $expense_date; ?>" required>
+                <input type="date" class="form-control" name="date" max="2999-12-31" value="<?php echo $expense_date; ?>" required>
               </div>
             </div>
             

--- a/expense_export_modal.php
+++ b/expense_export_modal.php
@@ -11,12 +11,12 @@
 				<div class="modal-body bg-white">
           <div class="form-group">
             <label>Date From</label>
-            <input type="date" class="form-control" name="date_from" value="<?php echo $dtf; ?>">
+            <input type="date" class="form-control" name="date_from" max="2999-12-31" value="<?php echo $dtf; ?>">
           </div>
    
           <div class="form-group">
             <label>Date To</label>
-            <input type="date" class="form-control" name="date_to" value="<?php echo $dtt; ?>">
+            <input type="date" class="form-control" name="date_to" max="2999-12-31" value="<?php echo $dtt; ?>">
           </div>
           
 				</div>

--- a/expense_refund_modal.php
+++ b/expense_refund_modal.php
@@ -21,7 +21,7 @@
                 <div class="input-group-prepend">
                   <span class="input-group-text"><i class="fa fa-fw fa-calendar"></i></span>
                 </div>
-                <input type="date" class="form-control" name="date" value="<?php echo date("Y-m-d"); ?>" required>
+                <input type="date" class="form-control" name="date" max="2999-12-31" value="<?php echo date("Y-m-d"); ?>" required>
               </div>
             </div>
             

--- a/expenses.php
+++ b/expenses.php
@@ -117,13 +117,13 @@ $num_rows = mysqli_fetch_row(mysqli_query($mysqli,"SELECT FOUND_ROWS()"));
           <div class="col-md-2">
             <div class="form-group">
               <label>Date From</label>
-              <input type="date" class="form-control" name="dtf" value="<?php echo $dtf; ?>">
+              <input type="date" class="form-control" name="dtf" max="2999-12-31" value="<?php echo $dtf; ?>">
             </div>
           </div>
           <div class="col-md-2">
             <div class="form-group">
               <label>Date To</label>
-              <input type="date" class="form-control" name="dtt" value="<?php echo $dtt; ?>">
+              <input type="date" class="form-control" name="dtt" max="2999-12-31" value="<?php echo $dtt; ?>">
             </div>
           </div>
         </div>    

--- a/invoice_add_modal.php
+++ b/invoice_add_modal.php
@@ -46,7 +46,7 @@
               <div class="input-group-prepend">
                 <span class="input-group-text"><i class="fa fa-fw fa-calendar"></i></span>
               </div>
-              <input type="date" class="form-control" name="date" value="<?php echo date("Y-m-d"); ?>" required>
+              <input type="date" class="form-control" name="date" max="2999-12-31" value="<?php echo date("Y-m-d"); ?>" required>
             </div>
           </div>
 

--- a/invoice_copy_modal.php
+++ b/invoice_copy_modal.php
@@ -18,7 +18,7 @@
               <div class="input-group-prepend">
                 <span class="input-group-text"><i class="fa fa-fw fa-calendar"></i></span>
               </div>
-              <input type="date" class="form-control" name="date" value="<?php echo date("Y-m-d"); ?>" required>
+              <input type="date" class="form-control" name="date" max="2999-12-31" value="<?php echo date("Y-m-d"); ?>" required>
             </div>
           </div>
           

--- a/invoice_edit_modal.php
+++ b/invoice_edit_modal.php
@@ -18,7 +18,7 @@
               <div class="input-group-prepend">
                 <span class="input-group-text"><i class="fa fa-fw fa-calendar"></i></span>
               </div>
-              <input type="date" class="form-control" name="date" value="<?php echo $invoice_date; ?>" required>
+              <input type="date" class="form-control" name="date" max="2999-12-31" value="<?php echo $invoice_date; ?>" required>
             </div>
           </div>
 
@@ -28,7 +28,7 @@
               <div class="input-group-prepend">
                 <span class="input-group-text"><i class="fa fa-fw fa-calendar-alt"></i></span>
               </div>
-              <input type="date" class="form-control" name="due" value="<?php echo $invoice_due; ?>" required>
+              <input type="date" class="form-control" name="due" max="2999-12-31" value="<?php echo $invoice_due; ?>" required>
             </div>
           </div>
 

--- a/invoice_payment_add_modal.php
+++ b/invoice_payment_add_modal.php
@@ -22,7 +22,7 @@
                   <div class="input-group-prepend">
                     <span class="input-group-text"><i class="fa fa-fw fa-calendar"></i></span>
                   </div>
-                  <input type="date" class="form-control" name="date" value="<?php echo date("Y-m-d"); ?>" required>
+                  <input type="date" class="form-control" name="date" max="2999-12-31" value="<?php echo date("Y-m-d"); ?>" required>
                 </div>
               </div>
 

--- a/invoices.php
+++ b/invoices.php
@@ -234,13 +234,13 @@
           <div class="col-md-2">
             <div class="form-group">
               <label>Date From</label>
-              <input type="date" class="form-control" name="dtf" value="<?php echo $dtf; ?>">
+              <input type="date" class="form-control" name="dtf" max="2999-12-31" value="<?php echo $dtf; ?>">
             </div>
           </div>
           <div class="col-md-2">
             <div class="form-group">
               <label>Date To</label>
-              <input type="date" class="form-control" name="dtt" value="<?php echo $dtt; ?>">
+              <input type="date" class="form-control" name="dtt" max="2999-12-31" value="<?php echo $dtt; ?>">
             </div>
           </div>
         </div>    

--- a/logs.php
+++ b/logs.php
@@ -104,13 +104,13 @@ $num_rows = mysqli_fetch_row(mysqli_query($mysqli,"SELECT FOUND_ROWS()"));
           <div class="col-md-2">
             <div class="form-group">
               <label>Date From</label>
-              <input type="date" class="form-control" name="dtf" value="<?php echo $dtf; ?>">
+              <input type="date" class="form-control" name="dtf" max="2999-12-31" value="<?php echo $dtf; ?>">
             </div>
           </div>
           <div class="col-md-2">
             <div class="form-group">
               <label>Date To</label>
-              <input type="date" class="form-control" name="dtt" value="<?php echo $dtt; ?>">
+              <input type="date" class="form-control" name="dtt" max="2999-12-31" value="<?php echo $dtt; ?>">
             </div>
           </div>
         </div>    

--- a/notifications_dismissed.php
+++ b/notifications_dismissed.php
@@ -59,13 +59,13 @@ $num_rows = mysqli_fetch_row(mysqli_query($mysqli,"SELECT FOUND_ROWS()"));
           <div class="col-md-2">
             <div class="form-group">
               <label>Date From</label>
-              <input type="date" class="form-control" name="dtf" value="<?php echo $dtf; ?>">
+              <input type="date" class="form-control" name="dtf" max="2999-12-31" value="<?php echo $dtf; ?>">
             </div>
           </div>
           <div class="col-md-2">
             <div class="form-group">
               <label>Date To</label>
-              <input type="date" class="form-control" name="dtt" value="<?php echo $dtt; ?>">
+              <input type="date" class="form-control" name="dtt" max="2999-12-31" value="<?php echo $dtt; ?>">
             </div>
           </div>
         </div>    

--- a/payments.php
+++ b/payments.php
@@ -107,13 +107,13 @@ $num_rows = mysqli_fetch_row(mysqli_query($mysqli,"SELECT FOUND_ROWS()"));
           <div class="col-md-2">
             <div class="form-group">
               <label>Date From</label>
-              <input type="date" class="form-control" name="dtf" value="<?php echo $dtf; ?>">
+              <input type="date" class="form-control" name="dtf" max="2999-12-31" value="<?php echo $dtf; ?>">
             </div>
           </div>
           <div class="col-md-2">
             <div class="form-group">
               <label>Date To</label>
-              <input type="date" class="form-control" name="dtt" value="<?php echo $dtt; ?>">
+              <input type="date" class="form-control" name="dtt" max="2999-12-31" value="<?php echo $dtt; ?>">
             </div>
           </div>
         </div>    

--- a/quote_add_modal.php
+++ b/quote_add_modal.php
@@ -47,7 +47,7 @@
               <div class="input-group-prepend">
                 <span class="input-group-text"><i class="fa fa-fw fa-calendar"></i></span>
               </div>
-              <input type="date" class="form-control" name="date" value="<?php echo date("Y-m-d"); ?>" required>
+              <input type="date" class="form-control" name="date" max="2999-12-31" value="<?php echo date("Y-m-d"); ?>" required>
             </div>
           </div>
           

--- a/quote_copy_modal.php
+++ b/quote_copy_modal.php
@@ -17,7 +17,7 @@
               <div class="input-group-prepend">
                 <span class="input-group-text"><i class="fa fa-fw fa-calendar"></i></span>
               </div>
-              <input type="date" class="form-control" name="date" value="<?php echo date("Y-m-d"); ?>" required>
+              <input type="date" class="form-control" name="date" max="2999-12-31" value="<?php echo date("Y-m-d"); ?>" required>
             </div>
           </div>
 

--- a/quote_edit_modal.php
+++ b/quote_edit_modal.php
@@ -18,7 +18,7 @@
               <div class="input-group-prepend">
                 <span class="input-group-text"><i class="fa fa-fw fa-calendar"></i></span>
               </div>
-              <input type="date" class="form-control" name="date" value="<?php echo $quote_date; ?>" required>
+              <input type="date" class="form-control" name="date" max="2999-12-31" value="<?php echo $quote_date; ?>" required>
             </div>
           </div>
 

--- a/quote_to_invoice_modal.php
+++ b/quote_to_invoice_modal.php
@@ -19,7 +19,7 @@
               <div class="input-group-prepend">
                 <span class="input-group-text"><i class="fa fa-fw fa-calendar"></i></span>
               </div>
-              <input type="date" class="form-control" name="date" value="<?php echo date("Y-m-d"); ?>" required>
+              <input type="date" class="form-control" name="date" max="2999-12-31" value="<?php echo date("Y-m-d"); ?>" required>
             </div>
           </div>
       

--- a/quotes.php
+++ b/quotes.php
@@ -108,13 +108,13 @@ $num_rows = mysqli_fetch_row(mysqli_query($mysqli,"SELECT FOUND_ROWS()"));
           <div class="col-md-2">
             <div class="form-group">
               <label>Date From</label>
-              <input type="date" class="form-control" name="dtf" value="<?php echo $dtf; ?>">
+              <input type="date" class="form-control" name="dtf" max="2999-12-31" value="<?php echo $dtf; ?>">
             </div>
           </div>
           <div class="col-md-2">
             <div class="form-group">
               <label>Date To</label>
-              <input type="date" class="form-control" name="dtt" value="<?php echo $dtt; ?>">
+              <input type="date" class="form-control" name="dtt" max="2999-12-31" value="<?php echo $dtt; ?>">
             </div>
           </div>
         </div>    

--- a/recurring_invoice_add_modal.php
+++ b/recurring_invoice_add_modal.php
@@ -46,7 +46,7 @@
               <div class="input-group-prepend">
                 <span class="input-group-text"><i class="fa fa-fw fa-calendar"></i></span>
               </div>
-              <input type="date" class="form-control" name="start_date" value="<?php echo date("Y-m-d"); ?>" required>
+              <input type="date" class="form-control" name="start_date" max="2999-12-31" value="<?php echo date("Y-m-d"); ?>" required>
             </div>
           </div>
           

--- a/recurring_invoice_edit_next_date_modal.php
+++ b/recurring_invoice_edit_next_date_modal.php
@@ -18,7 +18,7 @@
               <div class="input-group-prepend">
                 <span class="input-group-text"><i class="fa fa-fw fa-calendar"></i></span>
               </div>
-              <input type="date" class="form-control" name="next_date" value="<?php echo $recurring_next_date; ?>" required>
+              <input type="date" class="form-control" name="next_date" max="2999-12-31" value="<?php echo $recurring_next_date; ?>" required>
             </div>
           </div>
 

--- a/recurring_invoices.php
+++ b/recurring_invoices.php
@@ -108,13 +108,13 @@ $num_rows = mysqli_fetch_row(mysqli_query($mysqli,"SELECT FOUND_ROWS()"));
           <div class="col-md-2">
             <div class="form-group">
               <label>Date From</label>
-              <input type="date" class="form-control" name="dtf" value="<?php echo $dtf; ?>">
+              <input type="date" class="form-control" name="dtf" max="2999-12-31" value="<?php echo $dtf; ?>">
             </div>
           </div>
           <div class="col-md-2">
             <div class="form-group">
               <label>Date To</label>
-              <input type="date" class="form-control" name="dtt" value="<?php echo $dtt; ?>">
+              <input type="date" class="form-control" name="dtt" max="2999-12-31" value="<?php echo $dtt; ?>">
             </div>
           </div>
         </div>    

--- a/revenue_add_modal.php
+++ b/revenue_add_modal.php
@@ -18,7 +18,7 @@
                 <div class="input-group-prepend">
                   <span class="input-group-text"><i class="fa fa-fw fa-calendar"></i></span>
                 </div>
-                <input type="date" class="form-control" name="date" value="<?php echo date("Y-m-d"); ?>" required>
+                <input type="date" class="form-control" name="date" max="2999-12-31" value="<?php echo date("Y-m-d"); ?>" required>
               </div>
             </div>
 

--- a/revenue_edit_modal.php
+++ b/revenue_edit_modal.php
@@ -19,7 +19,7 @@
                 <div class="input-group-prepend">
                   <span class="input-group-text"><i class="fa fa-fw fa-calendar"></i></span>
                 </div>
-                <input type="date" class="form-control" name="date" value="<?php echo $revenue_date; ?>" required>
+                <input type="date" class="form-control" name="date" max="2999-12-31" value="<?php echo $revenue_date; ?>" required>
               </div>
             </div>
 

--- a/revenues.php
+++ b/revenues.php
@@ -108,13 +108,13 @@ $num_rows = mysqli_fetch_row(mysqli_query($mysqli,"SELECT FOUND_ROWS()"));
           <div class="col-md-2">
             <div class="form-group">
               <label>Date From</label>
-              <input type="date" class="form-control" name="dtf" value="<?php echo $dtf; ?>">
+              <input type="date" class="form-control" name="dtf" max="2999-12-31" value="<?php echo $dtf; ?>">
             </div>
           </div>
           <div class="col-md-2">
             <div class="form-group">
               <label>Date To</label>
-              <input type="date" class="form-control" name="dtt" value="<?php echo $dtt; ?>">
+              <input type="date" class="form-control" name="dtt" max="2999-12-31" value="<?php echo $dtt; ?>">
             </div>
           </div>
         </div>    

--- a/scheduled_ticket_add_modal.php
+++ b/scheduled_ticket_add_modal.php
@@ -82,7 +82,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text"><i class="fa fa-fw fa-calendar-day"></i></span>
                             </div>
-                            <input class="form-control" type="date" min="<?php echo date("Y-m-d"); ?>" name="start_date" required>
+                            <input class="form-control" type="date" name="start_date" min="<?php echo date("Y-m-d"); ?>" max="2999-12-31" required>
                         </div>
                     </div>
 

--- a/scheduled_ticket_edit_modal.php
+++ b/scheduled_ticket_edit_modal.php
@@ -35,7 +35,7 @@
               <div class="input-group-prepend">
                 <span class="input-group-text"><i class="fa fa-fw fa-calendar-day"></i></span>
               </div>
-              <input class="form-control" type="date" name="next_date" id="editTicketNextRun">
+              <input class="form-control" type="date" name="next_date" id="editTicketNextRun" max="2999-12-31">
             </div>
           </div>
 

--- a/ticket_invoice_add_modal.php
+++ b/ticket_invoice_add_modal.php
@@ -50,7 +50,7 @@
               <div class="input-group-prepend">
                 <span class="input-group-text"><i class="fa fa-fw fa-calendar"></i></span>
               </div>
-              <input type="date" class="form-control" name="date" value="<?php echo date("Y-m-d"); ?>" required>
+              <input type="date" class="form-control" name="date" max="2999-12-31" value="<?php echo date("Y-m-d"); ?>" required>
             </div>
           </div>
 

--- a/tickets.php
+++ b/tickets.php
@@ -252,13 +252,13 @@ $user_active_assigned_tickets = $row['total_tickets_assigned'];
                         <div class="col-md-2">
                             <div class="form-group">
                                 <label>Date From</label>
-                                <input type="date" class="form-control" name="dtf" value="<?php echo $dtf; ?>">
+                                <input type="date" class="form-control" name="dtf" max="2999-12-31" value="<?php echo $dtf; ?>">
                             </div>
                         </div>
                         <div class="col-md-2">
                             <div class="form-group">
                                 <label>Date To</label>
-                                <input type="date" class="form-control" name="dtt" value="<?php echo $dtt; ?>">
+                                <input type="date" class="form-control" name="dtt" max="2999-12-31" value="<?php echo $dtt; ?>">
                             </div>
                         </div>
                         <div class="col-md-2">

--- a/transfer_add_modal.php
+++ b/transfer_add_modal.php
@@ -18,7 +18,7 @@
                 <div class="input-group-prepend">
                   <span class="input-group-text"><i class="fa fa-fw fa-calendar"></i></span>
                 </div>
-                <input type="date" class="form-control" name="date" value="<?php echo date("Y-m-d"); ?>" required>
+                <input type="date" class="form-control" name="date" max="2999-12-31" value="<?php echo date("Y-m-d"); ?>" required>
               </div>
             </div>
             

--- a/transfer_edit_modal.php
+++ b/transfer_edit_modal.php
@@ -22,7 +22,7 @@
                 <div class="input-group-prepend">
                   <span class="input-group-text"><i class="fa fa-fw fa-calendar"></i></span>
                 </div>
-                <input type="date" class="form-control" name="date" value="<?php echo $transfer_date; ?>" required>
+                <input type="date" class="form-control" name="date" max="2999-12-31" value="<?php echo $transfer_date; ?>" required>
               </div>
             </div>
             

--- a/transfers.php
+++ b/transfers.php
@@ -109,13 +109,13 @@ $num_rows = mysqli_fetch_row(mysqli_query($mysqli,"SELECT FOUND_ROWS()"));
           <div class="col-md-2">
             <div class="form-group">
               <label>Date From</label>
-              <input type="date" class="form-control" name="dtf" value="<?php echo $dtf; ?>">
+              <input type="date" class="form-control" name="dtf" max="2999-12-31" value="<?php echo $dtf; ?>">
             </div>
           </div>
           <div class="col-md-2">
             <div class="form-group">
               <label>Date To</label>
-              <input type="date" class="form-control" name="dtt" value="<?php echo $dtt; ?>">
+              <input type="date" class="form-control" name="dtt" max="2999-12-31" value="<?php echo $dtt; ?>">
             </div>
           </div>
         </div>    

--- a/trip_add_modal.php
+++ b/trip_add_modal.php
@@ -17,7 +17,7 @@
                 <div class="input-group-prepend">
                   <span class="input-group-text"><i class="fa fa-fw fa-calendar"></i></span>
                 </div>
-                <input type="date" class="form-control" name="date" value="<?php echo date("Y-m-d"); ?>" required>
+                <input type="date" class="form-control" name="date" max="2999-12-31" value="<?php echo date("Y-m-d"); ?>" required>
               </div>
             </div>
             

--- a/trip_copy_modal.php
+++ b/trip_copy_modal.php
@@ -18,7 +18,7 @@
                 <div class="input-group-prepend">
                   <span class="input-group-text"><i class="fa fa-fw fa-calendar"></i></span>
                 </div>
-                <input type="date" class="form-control" name="date" value="<?php echo date("Y-m-d"); ?>" required>
+                <input type="date" class="form-control" name="date" max="2999-12-31" value="<?php echo date("Y-m-d"); ?>" required>
               </div>
             </div>
 

--- a/trip_edit_modal.php
+++ b/trip_edit_modal.php
@@ -19,7 +19,7 @@
                 <div class="input-group-prepend">
                   <span class="input-group-text"><i class="fa fa-fw fa-calendar"></i></span>
                 </div>
-                <input type="date" class="form-control" name="date" value="<?php echo $trip_date; ?>" required>
+                <input type="date" class="form-control" name="date" max="2999-12-31" value="<?php echo $trip_date; ?>" required>
               </div>
             </div>
             

--- a/trip_export_modal.php
+++ b/trip_export_modal.php
@@ -11,12 +11,12 @@
 				<div class="modal-body bg-white">
           <div class="form-group">
             <label>Date From</label>
-            <input type="date" class="form-control" name="date_from" value="<?php echo $dtf; ?>">
+            <input type="date" class="form-control" name="date_from" max="2999-12-31" value="<?php echo $dtf; ?>">
           </div>
    
           <div class="form-group">
             <label>Date To</label>
-            <input type="date" class="form-control" name="date_to" value="<?php echo $dtt; ?>">
+            <input type="date" class="form-control" name="date_to" max="2999-12-31" value="<?php echo $dtt; ?>">
           </div>
           
 				</div>

--- a/trips.php
+++ b/trips.php
@@ -118,13 +118,13 @@
           <div class="col-md-2">
             <div class="form-group">
               <label>Date From</label>
-              <input type="date" class="form-control" name="dtf" value="<?php echo $dtf; ?>">
+              <input type="date" class="form-control" name="dtf" max="2999-12-31" value="<?php echo $dtf; ?>">
             </div>
           </div>
           <div class="col-md-2">
             <div class="form-group">
               <label>Date To</label>
-              <input type="date" class="form-control" name="dtt" value="<?php echo $dtt; ?>">
+              <input type="date" class="form-control" name="dtt" max="2999-12-31" value="<?php echo $dtt; ?>">
             </div>
           </div>
         </div>    

--- a/vendors.php
+++ b/vendors.php
@@ -69,13 +69,13 @@ $num_rows = mysqli_fetch_row(mysqli_query($mysqli,"SELECT FOUND_ROWS()"));
           <div class="col-md-2">
             <div class="form-group">
               <label>Date From</label>
-              <input type="date" class="form-control" name="dtf" value="<?php echo $dtf; ?>">
+              <input type="date" class="form-control" name="dtf" max="2999-12-31" value="<?php echo $dtf; ?>">
             </div>
           </div>
           <div class="col-md-2">
             <div class="form-group">
               <label>Date To</label>
-              <input type="date" class="form-control" name="dtt" value="<?php echo $dtt; ?>">
+              <input type="date" class="form-control" name="dtt" max="2999-12-31" value="<?php echo $dtt; ?>">
             </div>
           </div>
         </div>    


### PR DESCRIPTION
Set a max date attribute for date input fields to prevent/discourage dates from going over 4 characters (client-side validation).
Closes #295 

![image](https://user-images.githubusercontent.com/32306651/208255093-a2e1e249-e7e0-4535-8bcb-d5d95da33001.png)