### PR TITLE
Calendar - Auto-set end date to 1 hr after start date when creating new events

### DIFF
--- a/calendar_event_add_modal.php
+++ b/calendar_event_add_modal.php
@@ -69,11 +69,10 @@
               <label>Start / End <strong class="text-danger">*</strong></label>
               <div class="form-row">
                 <div class="col-md-6 mb-3">
-                  <input type="datetime-local" class="form-control form-control-sm" name="start" required>
+                  <input type="datetime-local" class="form-control form-control-sm" id="event_add_start" name="start" required onblur="updateIncrementEndTime()">
                 </div>
                 <div class="col-md-6 mb-3">
-                  <input type="datetime-local" class="form-control form-control-sm" name="end" 
- required>
+                  <input type="datetime-local" class="form-control form-control-sm" id="event_add_end" name="end" required>
                 </div>
               </div>
 

--- a/calendar_events.php
+++ b/calendar_events.php
@@ -161,3 +161,28 @@ while($row = mysqli_fetch_array($sql)){
     });
 
   </script>
+
+<!-- Automatically set new event end date to 1 hr after start date -->
+<script>
+
+    // Function - called when user leaves field (onblur)
+    function updateIncrementEndTime() {
+
+        // Get the start date
+        let start = document.getElementById("event_add_start").value;
+
+        // Create a date object
+        let new_end = new Date(start);
+
+        // Set the end date to 1 hr in the future
+        new_end.setHours(new_end.getHours() + 1)
+
+        // Get the date back as a string, with the milliseconds trimmed off
+        new_end = new_end.toISOString().replace(/.\d+Z$/g, "");
+
+        // Update the end date field
+        document.getElementById("event_add_end").value = new_end;
+
+    }
+
+</script>


### PR DESCRIPTION
Add functionality to automatically adjust the end date for new calendar events to 1 hr after the start date
Closes #63 

![ezgif-2-e685ce4099](https://user-images.githubusercontent.com/32306651/208268108-c61e7605-c8e0-41c2-bede-c400b99da612.gif)
