### PR TITLE
Add check of database credentials during setup

### DIFF
--- a/setup.php
+++ b/setup.php
@@ -782,6 +782,14 @@ if(isset($_POST['add_database'])){
   $password = $_POST['password'];
   $config_base_url = $_SERVER['HTTP_HOST'] . dirname($_SERVER['REQUEST_URI']);
 
+  // Test database connection before writing it to config.php
+  try {
+    mysqli_connect($host, $username, $password, $database);
+  }
+  catch (Exception $e) {
+    exit("<b>Database connection failed - please check and try again</b> <br> <br> $e");
+  }
+
   $new_config = array();
   $new_config[] = "<?php\n\n";
   $new_config[] = sprintf("\$dbhost = '%s';\n", addslashes($host));

--- a/setup.php
+++ b/setup.php
@@ -785,8 +785,7 @@ if(isset($_POST['add_database'])){
   // Test database connection before writing it to config.php
   try {
     mysqli_connect($host, $username, $password, $database);
-  }
-  catch (Exception $e) {
+  } catch (Exception $e) {
     exit("<b>Database connection failed - please check and try again</b> <br> <br> $e");
   }
 


### PR DESCRIPTION
During setup, users are prompted for the database credentials. If the user enters the wrong credentials, they are still written to config.php. This results in setup loops as config.php exists, but the database connection fails. The fix is to delete config.php, but new users won't know that.

I've added a check that ensures the credentials are valid before writing them to config.php to prevent such loops.

![image](https://user-images.githubusercontent.com/32306651/209447649-e4e20fb3-e7d3-4585-a776-c6b287cd4a21.png)