### PR TITLE
Deduplicate client overview SQL queries

### DIFF
--- a/client_overview.php
+++ b/client_overview.php
@@ -15,38 +15,13 @@ $sql_logins = mysqli_query($mysqli,"SELECT * FROM logins WHERE login_client_id =
 // Expiring Items
 
 // Get Domains Expiring
+// TODO: Need to work out whether we can remove this one too - very similar functionality in inc_all_client.php
 $sql_domains_expiring = mysqli_query($mysqli,"SELECT * FROM domains
     WHERE domain_client_id = $client_id
     AND domain_expire != '0000-00-00'
     AND domain_archived_at IS NULL
     AND domain_expire < CURRENT_DATE + INTERVAL 30 DAY
     AND company_id = $session_company_id ORDER BY domain_expire DESC"
-);
-
-// Get Asset Warranties Expiring
-$sql_asset_warranties_expiring = mysqli_query($mysqli,"SELECT * FROM assets
-    WHERE asset_client_id = $client_id
-    AND asset_warranty_expire != '0000-00-00'
-    AND asset_archived_at IS NULL  
-    AND asset_warranty_expire < CURRENT_DATE + INTERVAL 90 DAY
-    AND company_id = $session_company_id ORDER BY asset_warranty_expire DESC"
-);
-
-// Get Assets Retiring
-$sql_asset_retire = mysqli_query($mysqli,"SELECT * FROM assets
-    WHERE asset_client_id = $client_id
-    AND asset_install_date != '0000-00-00'
-    AND asset_archived_at IS NULL 
-    AND asset_install_date + INTERVAL 7 YEAR < CURRENT_DATE + INTERVAL 90 DAY
-    AND company_id = $session_company_id ORDER BY asset_install_date DESC"
-);
-
-// Get Stale Tickets
-$sql_tickets_stale = mysqli_query($mysqli,"SELECT * FROM tickets
-    WHERE ticket_client_id = $client_id
-    AND ticket_created_at < CURRENT_DATE - INTERVAL 14 DAY
-    AND ticket_status != 'Closed'
-    AND company_id = $session_company_id ORDER BY ticket_created_at DESC"
 );
 
 ?>


### PR DESCRIPTION
Tidying up some duplicated SQL queries on client_overview.php since we re-did the main [inc_all_client.php file](https://github.com/itflow-org/itflow/blob/master/inc_all_client.php#L172).

Can you check the domain expiring query too when you get a second, please? It's slightly different on the client_overview.php and the inc_all_client.php page.