### PR TITLE
Show expiring certs in the client side navbar

### DIFF
--- a/client_overview.php
+++ b/client_overview.php
@@ -15,7 +15,6 @@ $sql_logins = mysqli_query($mysqli,"SELECT * FROM logins WHERE login_client_id =
 // Expiring Items
 
 // Get Domains Expiring
-// TODO: Need to work out whether we can remove this one too - very similar functionality in inc_all_client.php
 $sql_domains_expiring = mysqli_query($mysqli,"SELECT * FROM domains
     WHERE domain_client_id = $client_id
     AND domain_expire != '0000-00-00'

--- a/client_side_nav.php
+++ b/client_side_nav.php
@@ -108,10 +108,15 @@
             <i class="nav-icon fas fa-lock"></i>
             <p>
               Certificates
+
               <?php 
               if($num_certificates > 0){ ?>
               <span class="right badge badge-light"><?php echo $num_certificates; ?></span>
               <?php } ?>
+
+            <?php if($num_certs_expiring > 0){ ?>
+                <span class="right fa fa-fw fa-circle text-warning"></span>
+            <?php } ?>
             </p>
           </a>
         </li>

--- a/inc_all_client.php
+++ b/inc_all_client.php
@@ -171,7 +171,7 @@ if(isset($_GET['client_id'])){
 
     // Expiring Items
 
-    // Get Domains Expiring within 30 Days
+    // Count Domains Expiring within 30 Days
     $row = mysqli_fetch_assoc(mysqli_query($mysqli,"SELECT COUNT('domain_id') AS num FROM domains
       WHERE domain_client_id = $client_id
       AND domain_expire != '0000-00-00'
@@ -181,7 +181,7 @@ if(isset($_GET['client_id'])){
     ));
     $num_domains_expiring = $row['num'];
 
-    // Get Certificates Expiring within 30 Days
+    // Count Certificates Expiring within 30 Days
     $row = mysqli_fetch_assoc(mysqli_query($mysqli,"SELECT COUNT('certificate_id') AS num FROM certificates
       WHERE certificate_client_id = $client_id
       AND certificate_expire != '0000-00-00'

--- a/inc_all_client.php
+++ b/inc_all_client.php
@@ -175,11 +175,21 @@ if(isset($_GET['client_id'])){
     $row = mysqli_fetch_assoc(mysqli_query($mysqli,"SELECT COUNT('domain_id') AS num FROM domains
       WHERE domain_client_id = $client_id
       AND domain_expire != '0000-00-00'
-      AND domain_archived_at IS NULL
       AND domain_expire < CURRENT_DATE + INTERVAL 30 DAY
+      AND domain_archived_at IS NULL
       AND company_id = $session_company_id"
     ));
     $num_domains_expiring = $row['num'];
+
+    // Get Certificates Expiring within 30 Days
+    $row = mysqli_fetch_assoc(mysqli_query($mysqli,"SELECT COUNT('certificate_id') AS num FROM certificates
+      WHERE certificate_client_id = $client_id
+      AND certificate_expire != '0000-00-00'
+      AND certificate_expire < CURRENT_DATE + INTERVAL 30 DAY
+      AND certificate_archived_at IS NULL
+      AND company_id = $session_company_id"
+    ));
+    $num_certs_expiring = $row['num'];
 
     // Get Asset Warranties Expiring
     $sql_asset_warranties_expiring = mysqli_query($mysqli,"SELECT * FROM assets


### PR DESCRIPTION
Similarly to how we indicate an expiring domain in the client navbar with a yellow circle, do the same for certificates
![image](https://user-images.githubusercontent.com/32306651/210173700-ea090d70-0b22-477a-8a85-a63708a53709.png)
