### PR TITLE
SHOWING REVENUES IN EACH PARTICULAR MONTH COLUMN 

### DIFF
--- a/report_income_summary.php
+++ b/report_income_summary.php
@@ -92,7 +92,7 @@ $sql_categories = mysqli_query($mysqli,"SELECT * FROM categories WHERE category_
                 $payment_amount_for_month = $row['payment_amount_for_month'];
 
                 //Revenues
-                $sql_revenues = mysqli_query($mysqli,"SELECT SUM(revenue_amount) AS revenue_amount_for_month FROM revenues WHERE revenue_id = $category_id AND YEAR(revenue_date) = $year AND MONTH(revenue_date) = $month");
+                $sql_revenues = mysqli_query($mysqli,"SELECT SUM(revenue_amount) AS revenue_amount_for_month FROM revenues WHERE revenue_category_id = $category_id AND YEAR(revenue_date) = $year AND MONTH(revenue_date) = $month");
                 $row = mysqli_fetch_array($sql_revenues);
                 $revenues_amount_for_month = $row['revenue_amount_for_month'];
 

--- a/ticket.php
+++ b/ticket.php
@@ -625,10 +625,36 @@ if($ticket_status !== "Closed"){ ?>
   <!-- Ticket Time Tracking JS -->
   <script type="text/javascript">
       // Default values
-      var hours = 0;
-      var minutes = 0;
-      var seconds = 0;
-      setInterval(countTime, 1000);
+     // var hours = 0;
+      //var minutes = 0;
+      //var seconds = 0;
+var startDateTime = new Date("<?= $ticket_created_at;?>"); // (start time and date from DB)
+var startStamp = startDateTime.getTime();
+
+var newDate = new Date();
+var newStamp = newDate.getTime();
+
+var timer; // for storing the interval (to stop or pause later if needed)
+
+function updateClock() {
+    newDate = new Date();
+    newStamp = newDate.getTime();
+    var diff = Math.round((newStamp-startStamp)/1000);
+    
+    var d = Math.floor(diff/(24*60*60)); 
+    diff = diff-(d*24*60*60);
+    var h = Math.floor(diff/(60*60));
+    diff = diff-(h*60*60);
+    var m = Math.floor(diff/(60));
+    diff = diff-(m*60);
+    var s = diff;
+    var time_worked = pad(h) + ":" + pad(m) + ":" + pad(s);
+    document.getElementById("time_worked").value = time_worked;
+  
+}
+
+
+timer = setInterval(updateClock, 1000);
 
       // Counter
       function countTime()
@@ -644,8 +670,8 @@ if($ticket_status !== "Closed"){ ?>
           }
 
           // Total timeworked
-          var time_worked = pad(hours) + ":" + pad(minutes) + ":" + pad(seconds);
-          document.getElementById("time_worked").value = time_worked;
+        //  var time_worked = pad(hours) + ":" + pad(minutes) + ":" + pad(seconds);
+         // document.getElementById("time_worked").value = time_worked;
       }
 
       // Allows manually adjusting the timer

--- a/ticket.php
+++ b/ticket.php
@@ -625,36 +625,10 @@ if($ticket_status !== "Closed"){ ?>
   <!-- Ticket Time Tracking JS -->
   <script type="text/javascript">
       // Default values
-     // var hours = 0;
-      //var minutes = 0;
-      //var seconds = 0;
-var startDateTime = new Date("<?= $ticket_created_at;?>"); // (start time and date from DB)
-var startStamp = startDateTime.getTime();
-
-var newDate = new Date();
-var newStamp = newDate.getTime();
-
-var timer; // for storing the interval (to stop or pause later if needed)
-
-function updateClock() {
-    newDate = new Date();
-    newStamp = newDate.getTime();
-    var diff = Math.round((newStamp-startStamp)/1000);
-    
-    var d = Math.floor(diff/(24*60*60)); 
-    diff = diff-(d*24*60*60);
-    var h = Math.floor(diff/(60*60));
-    diff = diff-(h*60*60);
-    var m = Math.floor(diff/(60));
-    diff = diff-(m*60);
-    var s = diff;
-    var time_worked = pad(h) + ":" + pad(m) + ":" + pad(s);
-    document.getElementById("time_worked").value = time_worked;
-  
-}
-
-
-timer = setInterval(updateClock, 1000);
+      var hours = 0;
+      var minutes = 0;
+      var seconds = 0;
+      setInterval(countTime, 1000);
 
       // Counter
       function countTime()
@@ -670,8 +644,8 @@ timer = setInterval(updateClock, 1000);
           }
 
           // Total timeworked
-        //  var time_worked = pad(hours) + ":" + pad(minutes) + ":" + pad(seconds);
-         // document.getElementById("time_worked").value = time_worked;
+          var time_worked = pad(hours) + ":" + pad(minutes) + ":" + pad(seconds);
+          document.getElementById("time_worked").value = time_worked;
       }
 
       // Allows manually adjusting the timer

--- a/users.php
+++ b/users.php
@@ -88,9 +88,10 @@
               ORDER BY log_id DESC LIMIT 1"
             );
             $row = mysqli_fetch_array($sql_last_login);
-            $log_created_at = $row['log_created_at'];
-            $log_ip = htmlentities($row['log_ip']);
-            $log_user_agent = htmlentities($row['log_user_agent']);
+            $log_created_at = empty($row['log_created_at']) ? date('Y - m - d h:i:s') : $row['log_created_at'];
+            $log_ip = empty(($row['log_ip'])) ? '' : htmlentities($row['log_ip']);
+            $log_user_agent = empty(($row['log_user_agent'])) ? '' : $row['log_user_agent'];
+
 
             $last_login = "$log_ip - $log_user_agent";
             if(empty($last_login)){


### PR DESCRIPTION
So when you go under `Reports -> Income` to view the income summary, the revenues in each particular month are not shown except under the Total bottom row where they are added together with other incomes. This is because the code fetching the revenues in each particular month always picks an auto increment id . Check this code which picks the revenues in each particular month in `report_income_summary.php on line 65`:

 `$sql_revenues = mysqli_query($mysqli,"SELECT SUM(revenue_amount) AS revenue_amount_for_month FROM revenues WHERE revenue_id = $category_id AND YEAR(revenue_date) = $year AND MONTH(revenue_date) = $month");`
The code looks for the id of revenue_id instead of the revenue_category_id