### PR TITLE
SHOWING REVENUES IN EACH PARTICULAR MONTH COLUMN

### DIFF
--- a/report_income_summary.php
+++ b/report_income_summary.php
@@ -92,7 +92,7 @@ $sql_categories = mysqli_query($mysqli,"SELECT * FROM categories WHERE category_
                 $payment_amount_for_month = $row['payment_amount_for_month'];
 
                 //Revenues
-                $sql_revenues = mysqli_query($mysqli,"SELECT SUM(revenue_amount) AS revenue_amount_for_month FROM revenues WHERE revenue_id = $category_id AND YEAR(revenue_date) = $year AND MONTH(revenue_date) = $month");
+                $sql_revenues = mysqli_query($mysqli,"SELECT SUM(revenue_amount) AS revenue_amount_for_month FROM revenues WHERE revenue_category_id = $category_id AND YEAR(revenue_date) = $year AND MONTH(revenue_date) = $month");
                 $row = mysqli_fetch_array($sql_revenues);
                 $revenues_amount_for_month = $row['revenue_amount_for_month'];
 


### PR DESCRIPTION
So when you go under `Reports -> Income` to view the income summary, the revenues in each particular month are not shown except under the Total bottom row where they are added together with other incomes. This is because the code fetching the revenues in each particular month always picks an auto increment id . Check this code which picks the revenues in each particular month in `report_income_summary.php on line 95`:

`$sql_revenues = mysqli_query($mysqli,"SELECT SUM(revenue_amount) AS revenue_amount_for_month FROM revenues WHERE revenue_id = $category_id AND YEAR(revenue_date) = $year AND MONTH(revenue_date) = $month");`
The code looks for the id of `revenue_id` instead of the `revenue_category_id`