### PR TITLE
removed warning

### DIFF
--- a/login.php
+++ b/login.php
@@ -55,7 +55,10 @@ if(isset($_POST['login'])){
         }
 
         $row = mysqli_fetch_assoc(mysqli_query($mysqli, "SELECT * FROM users LEFT JOIN user_settings on users.user_id = user_settings.user_id WHERE user_email = '$email' AND user_archived_at IS NULL"));
-        if (password_verify($password, $row['user_password'])) {
+        
+        if ($row) {
+        
+        if (password_verify($password, $row['user_password'])) 
 
             // User variables
             $token = $row['user_token'];


### PR DESCRIPTION
If you mistakenly enter the **wrong credentials (email address)** while login in, it was throwing the warning of "Trying to access array offset on value of type null". This is because on line `57 in login.php` there is this code:

`$row = mysqli_fetch_assoc(mysqli_query($mysqli, "SELECT * FROM users LEFT JOIN user_settings on users.user_id = user_settings.user_id WHERE user_email = '$email' AND user_archived_at IS NULL"));
if (password_verify($password, $row['user_password'])) {......`

But if the email does not exist (wrong credentials) then `$row will become NULL` and the password verify will compare the input password with NULL which will throw a warning. Inserted a condition to prevent password verify if the email does not exist.
