### PR TITLE
Moving docker $repo_branch var to config.php

### DIFF
--- a/settings_update.php
+++ b/settings_update.php
@@ -1,12 +1,12 @@
 <?php
 include("inc_all_settings.php");
 include("database_version.php");
+include("config.php")
 ?>
 
 <?php
 
-//fetch the latest code changes but don't apply them\
-$repo_branch = 'master';
+//fetch the latest code changes but don't apply them
 exec("git fetch", $output, $result);
 $latest_version = exec("git rev-parse origin/$repo_branch");
 $current_version = exec("git rev-parse HEAD");

--- a/setup.php
+++ b/setup.php
@@ -799,6 +799,7 @@ if(isset($_POST['add_database'])){
   $new_config[] = "\$config_app_name = 'ITFlow';\n";
   $new_config[] = sprintf("\$config_base_url = '%s';\n", addslashes($config_base_url));
   $new_config[] = "\$config_https_only = TRUE;\n";
+  $new_config[] = "\$repo_branch = 'master';\n";
 
   file_put_contents("config.php", $new_config);
 


### PR DESCRIPTION
This is to avoid changing settings_update.php post docker entrypoint.sh manipulation. Instead have all variable changes occur within config.php for consistency. 