### PR TITLE
Testing adding a background script to keep sessions alive

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -7,11 +7,11 @@
 	<!-- ./wrapper -->
 
 	<!-- REQUIRED SCRIPTS -->
-	
+
 	<!-- Bootstrap 4 -->
 	<script src="plugins/bootstrap/js/bootstrap.bundle.min.js"></script>
 	<!-- Custom js-->
-	
+
 	<script src="plugins/moment/moment.min.js"></script>
 	<script src="plugins/chart.js/Chart.min.js"></script>
 	<script src="plugins/tempusdominus-bootstrap-4/js/tempusdominus-bootstrap-4.min.js"></script>
@@ -26,10 +26,13 @@
 	<!-- AdminLTE App -->
 	<script src="dist/js/adminlte.min.js"></script>
 	<script src="js/app.js"></script>
+
+    <!-- Keep sessions alive -->
+    <script src="js/keep_alive.js"></script>
 	</body>
 </html>
 
-<?php 
+<?php
 
 // Calculate Execution time Uncomment for test
 

--- a/js/keep_alive.js
+++ b/js/keep_alive.js
@@ -1,0 +1,15 @@
+// Testing this keep alive JS function due to issues reported with session cookies timing out too soon
+function keep_session_alive() {
+    //Send a GET request to ajax.php every. This should be enough for PHP to see the session is still active.
+    jQuery.get(
+        "ajax.php",
+        {},
+        function(nothing) {
+            // Don't care
+        }
+    );
+}
+
+// Call function every 10 mins
+setInterval(keep_session_alive, 600000);
+


### PR DESCRIPTION
Add a background bit of javascript that loads with most pages. This will call ajax.php (with no params) which should "renew" the login session and ensure it doesn't get garbage collected (though I'm still not entirely sure why that happens - unable to reproduce myself).

Related to https://forum.itflow.org/d/85-ticket-creation-box-allowed-when-auto-logged-out and https://forum.itflow.org/d/71-changing-auto-logoff-time