### PR TITLE
Re-add domain refreshing to cron

### DIFF
--- a/cron.php
+++ b/cron.php
@@ -412,7 +412,7 @@ while($row = mysqli_fetch_array($sql_companies)){
 
             } //End if Autosend is on
         } //End Recurring Invoices Loop
-    
+
         if($config_telemetry == 1){
 
             $current_version = exec("git rev-parse HEAD");
@@ -435,11 +435,11 @@ while($row = mysqli_fetch_array($sql_companies)){
 
             // Invoice Count
             $row = mysqli_fetch_assoc(mysqli_query($mysqli,"SELECT COUNT('invoice_id') AS num FROM invoices"));
-            $invoice_count = $row['num'];  
+            $invoice_count = $row['num'];
 
             // Revenue Count
             $row = mysqli_fetch_assoc(mysqli_query($mysqli,"SELECT COUNT('revenue_id') AS num FROM revenues"));
-            $revenue_count = $row['num'];  
+            $revenue_count = $row['num'];
 
             // Recurring Count
             $row = mysqli_fetch_assoc(mysqli_query($mysqli,"SELECT COUNT('recurring_id') AS num FROM recurring"));
@@ -460,7 +460,7 @@ while($row = mysqli_fetch_array($sql_companies)){
             // Payment Count
             $row = mysqli_fetch_assoc(mysqli_query($mysqli,"SELECT COUNT('payment_id') AS num FROM payments WHERE payment_invoice_id > 0"));
             $payment_count = $row['num'];
-            
+
             // Company Vendor Count
             $row = mysqli_fetch_assoc(mysqli_query($mysqli,"SELECT COUNT('vendor_id') AS num FROM vendors WHERE vendor_template = 0 AND vendor_client_id = 0"));
             $company_vendor_count = $row['num'];
@@ -535,7 +535,7 @@ while($row = mysqli_fetch_array($sql_companies)){
 
             // Document Template Count
             $row = mysqli_fetch_assoc(mysqli_query($mysqli,"SELECT COUNT('document_id') AS num FROM documents WHERE document_template = 1"));
-            $document_template_count = $row['num'];       
+            $document_template_count = $row['num'];
 
             // Shared Item Count
             $row = mysqli_fetch_assoc(mysqli_query($mysqli,"SELECT COUNT('item_id') AS num FROM shared_items"));

--- a/cron.php
+++ b/cron.php
@@ -55,6 +55,27 @@ while($row = mysqli_fetch_array($sql_companies)){
         //Logging
         mysqli_query($mysqli,"INSERT INTO logs SET log_type = 'Cron', log_action = 'Started', log_description = 'Cron started for $company_name', company_id = $company_id");
 
+
+        // REFRESH DOMAIN WHOIS DATA (1 a day)
+        // Get the oldest updated domain (MariaDB shows NULLs first when ordering by default)
+        $row = mysqli_fetch_array(mysqli_query($mysqli, "SELECT domain_id, domain_name FROM `domains` WHERE company_id = $company_id ORDER BY domain_updated_at LIMIT 1"));
+
+        if ($row) {
+            $domain_id = $row['domain_id'];
+            $domain_name = $row['domain_name'];
+
+            $expire = getDomainExpirationDate($domain_name);
+            $records = getDomainRecords($domain_name);
+            $a = mysqli_real_escape_string($mysqli, $records['a']);
+            $ns = mysqli_real_escape_string($mysqli, $records['ns']);
+            $mx = mysqli_real_escape_string($mysqli, $records['mx']);
+            $txt = mysqli_real_escape_string($mysqli, $records['txt']);
+            $whois = mysqli_real_escape_string($mysqli, $records['whois']);
+
+            // Update the domain
+            mysqli_query($mysqli,"UPDATE domains SET domain_name = '$domain_name',  domain_expire = '$expire', domain_ip = '$a', domain_name_servers = '$ns', domain_mail_servers = '$mx', domain_txt = '$txt', domain_raw_whois = '$whois' WHERE domain_id = $domain_id");
+        }
+
         // GET NOTIFICATIONS
 
         // DOMAINS EXPIRING


### PR DESCRIPTION
Add domain info (Expiry, WHOIS, A, NS, MX, TXT) refreshing - one domain per day (sorted by oldest updated).

I know this was previously [removed](https://github.com/itflow-org/itflow/commit/dbea44591c9590b1068c455ec09aad5a72d95767) due to it causing issues with invoice/reminder emails.

I've added the company_id attribute this time (even though it's soon to be removed) as I think that was the issue before. 

I've done some testing on my dev instance and everything seems to be working as far as I can see. Could you please do some testing on your end and let me know?

Also worth noting I've converted cron to 4 spaces now, instead of 2.

Thanks!