### PR TITLE
fixes #477

### DIFF
--- a/ajax.php
+++ b/ajax.php
@@ -313,7 +313,7 @@ if (isset($_GET['scheduled_ticket_get_json_details'])) {
  * When provided with a TOTP secret, returns a 6-digit code
  */
 if (isset($_GET['get_totp_token'])) {
-    $otp = TokenAuth6238::getTokenCode($_GET['totp_secret']);
+    $otp = TokenAuth6238::getTokenCode(strtoupper($_GET['totp_secret']));
 
     echo json_encode($otp);
 }


### PR DESCRIPTION
Fixed logic incompatibility between AJAX handler and base32.

Object usage convention wasn't being adhered to -- the base32 library doesn't play nicely with tokens that don't adhere to the convention of using uppercase alphabetical 32igits.

This fixes TOTP for my deployment referenced here: https://github.com/itflow-org/itflow/issues/477 