### PR TITLE
Ticketing Updates - Change client

### DIFF
--- a/ajax.php
+++ b/ajax.php
@@ -345,6 +345,45 @@ if (isset($_GET['quote_get_json_details'])) {
 }
 
 /*
+ * Returns sorted list of active clients
+ */
+if (isset($_GET['get_active_clients'])) {
+
+    $client_sql = mysqli_query(
+        $mysqli,
+        "SELECT client_id, client_name FROM clients
+        WHERE client_archived_at IS NULL
+        ORDER BY client_accessed_at DESC"
+    );
+
+    while ($row = mysqli_fetch_array($client_sql)) {
+        $response['clients'][] = $row;
+    }
+
+    echo json_encode($response);
+}
+
+/*
+ * Returns ordered list of active contacts for a specified client
+ */
+if (isset($_GET['get_client_contacts'])) {
+    $client_id = intval($_GET['client_id']);
+
+    $contact_sql = mysqli_query(
+        $mysqli,
+        "SELECT contact_id, contact_name FROM contacts
+        WHERE contacts.contact_archived_at IS NULL AND contact_client_id = $client_id
+        ORDER BY contact_important DESC, contact_name"
+    );
+
+    while ($row = mysqli_fetch_array($contact_sql)) {
+        $response['contacts'][] = $row;
+    }
+
+    echo json_encode($response);
+}
+
+/*
  * Dynamic TOTP for client login page
  * When provided with a TOTP secret, returns a 6-digit code
  */

--- a/database_updates.php
+++ b/database_updates.php
@@ -865,15 +865,15 @@ if (LATEST_DATABASE_VERSION > CURRENT_DATABASE_VERSION) {
         mysqli_query($mysqli, "ALTER TABLE `client_tags` CHANGE `client_id` `client_tags_client_id` INT NOT NULL");
         mysqli_query($mysqli, "ALTER TABLE `client_tags` CHANGE `tag_id` `client_tags_tag_id` INT NOT NULL");
 
-    // Then, update the database to the next sequential version
-     mysqli_query($mysqli, "UPDATE `settings` SET `config_current_database_version` = '0.4.4'");
+        // Then, update the database to the next sequential version
+        mysqli_query($mysqli, "UPDATE `settings` SET `config_current_database_version` = '0.4.4'");
     }
 
     if (CURRENT_DATABASE_VERSION == '0.4.4') {
-    // Insert queries here required to update to DB version 0.4.5
+        // Insert queries here required to update to DB version 0.4.5
         mysqli_query($mysqli, "ALTER TABLE `client_tags` CHANGE `client_tags_client_id` `client_tag_client_id` INT NOT NULL");
         mysqli_query($mysqli, "ALTER TABLE `client_tags` CHANGE `client_tags_tag_id` `client_tag_tag_id` INT NOT NULL");
-    // Then, update the database to the next sequential version
+        // Then, update the database to the next sequential version
         mysqli_query($mysqli, "UPDATE `settings` SET `config_current_database_version` = '0.4.5'");
     }
 
@@ -940,11 +940,17 @@ if (LATEST_DATABASE_VERSION > CURRENT_DATABASE_VERSION) {
         mysqli_query($mysqli, "UPDATE `settings` SET `config_current_database_version` = '0.4.8'");
     }
 
-//if (CURRENT_DATABASE_VERSION == '0.4.8') {
-    // Insert queries here required to update to DB version 0.4.9
+    if (CURRENT_DATABASE_VERSION == '0.4.8') {
+        mysqli_query($mysqli, "ALTER TABLE `tickets` ADD `ticket_source` VARCHAR(255) NULL DEFAULT NULL AFTER `ticket_number`");
+
+        mysqli_query($mysqli, "UPDATE `settings` SET `config_current_database_version` = '0.4.9'");
+    }
+
+    //if (CURRENT_DATABASE_VERSION == '0.4.9') {
+    // Insert queries here required to update to DB version 0.5.0
 
     // Then, update the database to the next sequential version
-    // mysqli_query($mysqli, "UPDATE `settings` SET `config_current_database_version` = '0.4.9'");
+    // mysqli_query($mysqli, "UPDATE `settings` SET `config_current_database_version` = '0.5.0'");
     //}
 
 } else {

--- a/database_version.php
+++ b/database_version.php
@@ -5,4 +5,4 @@
  * It is used in conjunction with database_updates.php
  */
 
-DEFINE("LATEST_DATABASE_VERSION", "0.4.8");
+DEFINE("LATEST_DATABASE_VERSION", "0.4.9");

--- a/db.sql
+++ b/db.sql
@@ -1280,6 +1280,7 @@ CREATE TABLE `tickets` (
   `ticket_id` int(11) NOT NULL AUTO_INCREMENT,
   `ticket_prefix` varchar(200) DEFAULT NULL,
   `ticket_number` int(11) NOT NULL,
+  `ticket_source` varchar(255) DEFAULT NULL,
   `ticket_category` varchar(200) DEFAULT NULL,
   `ticket_subject` varchar(200) NOT NULL,
   `ticket_details` longtext NOT NULL,

--- a/js/ticket_change_client.js
+++ b/js/ticket_change_client.js
@@ -3,16 +3,15 @@
  */
 
 // Modal loaded listener - populate client select
-changeClientModalLoad = document.getElementById('clientChangeTicketModalLoad');
+const changeClientModalLoad = document.getElementById('clientChangeTicketModalLoad');
 changeClientModalLoad.addEventListener('click', function() {
     populateChangeClientModal_Clients();
 })
 
 // Client selected listener - populate contact select
 //  We seem to have to use jQuery to listen for events, as the client input is a select2 component?
-clientSelectDropdown = document.getElementById("changeClientSelect");
+const clientSelectDropdown = document.getElementById("changeClientSelect");
 $(clientSelectDropdown).on('select2:select', function (e) {
-    console.log("Fired contacts listener!!!!!!")
     let client_id = $(this).find(':selected').val();
     populateChangeClientModal_Contacts(client_id);
 });
@@ -43,7 +42,7 @@ function populateChangeClientModal_Clients() {
             // Client dropdown already defined in listeners as clientSelectDropdown
 
             // Clear dropdown
-            var i, L = clientSelectDropdown.options.length -1;
+            let i, L = clientSelectDropdown.options.length - 1;
             for (i = L; i >= 0; i--) {
                 clientSelectDropdown.remove(i);
             }
@@ -76,10 +75,10 @@ function populateChangeClientModal_Contacts(client_id) {
             const contacts = response.contacts;
 
             // Contacts dropdown
-            var contactSelectDropdown = document.getElementById("changeContactSelect");
+            const contactSelectDropdown = document.getElementById("changeContactSelect");
 
             // Clear Category dropdown
-            var i, L = contactSelectDropdown.options.length -1;
+            let i, L = contactSelectDropdown.options.length - 1;
             for (i = L; i >= 0; i--) {
                 contactSelectDropdown.remove(i);
             }

--- a/js/ticket_change_client.js
+++ b/js/ticket_change_client.js
@@ -1,0 +1,95 @@
+/*
+ *   LISTENERS
+ */
+
+// Modal loaded listener - populate client select
+changeClientModalLoad = document.getElementById('clientChangeTicketModalLoad');
+changeClientModalLoad.addEventListener('click', function() {
+    populateChangeClientModal_Clients();
+})
+
+// Client selected listener - populate contact select
+//  We seem to have to use jQuery to listen for events, as the client input is a select2 component?
+clientSelectDropdown = document.getElementById("changeClientSelect");
+$(clientSelectDropdown).on('select2:select', function (e) {
+    console.log("Fired contacts listener!!!!!!")
+    let client_id = $(this).find(':selected').val();
+    populateChangeClientModal_Contacts(client_id);
+});
+
+
+/*
+ *   FUNCTIONS
+ */
+
+// Populate client list function
+function populateChangeClientModal_Clients() {
+
+    // Get current client ID
+    let current_client_id = document.getElementById("client_id").value;
+
+    // Send a GET request to ajax.php as ajax.php?get_active_clients=true
+    jQuery.get(
+        "ajax.php",
+        {get_active_clients: 'true'},
+        function(data) {
+
+            // If we get a response from ajax.php, parse it as JSON
+            const response = JSON.parse(data);
+
+            // Access the data for clients (multiple)
+            const clients = response.clients;
+
+            // Client dropdown already defined in listeners as clientSelectDropdown
+
+            // Clear dropdown
+            var i, L = clientSelectDropdown.options.length -1;
+            for (i = L; i >= 0; i--) {
+                clientSelectDropdown.remove(i);
+            }
+            clientSelectDropdown[clientSelectDropdown.length] = new Option('- Client -', '0');
+
+            // Populate dropdown
+            clients.forEach(client => {
+                if (parseInt(current_client_id) !== parseInt(client.client_id)) {
+                    // Show clients returned (excluding the current client ID - we can't change a ticket client to itself)
+                    clientSelectDropdown[clientSelectDropdown.length] = new Option(client.client_name, client.client_id);
+                }
+            });
+
+        }
+    );
+}
+
+// Populate client contact function (after a client is selected)
+function populateChangeClientModal_Contacts(client_id) {
+    // Send a GET request to ajax.php as ajax.php?get_client_contacts=true&client_id=NUM
+    jQuery.get(
+        "ajax.php",
+        {get_client_contacts: 'true', client_id: client_id},
+        function(data) {
+
+            // If we get a response from ajax.php, parse it as JSON
+            const response = JSON.parse(data);
+
+            // Access the data for contacts (multiple)
+            const contacts = response.contacts;
+
+            // Contacts dropdown
+            var contactSelectDropdown = document.getElementById("changeContactSelect");
+
+            // Clear Category dropdown
+            var i, L = contactSelectDropdown.options.length -1;
+            for (i = L; i >= 0; i--) {
+                contactSelectDropdown.remove(i);
+            }
+            contactSelectDropdown[contactSelectDropdown.length] = new Option('- Contact -', '0');
+
+            // Populate dropdown
+            contacts.forEach(contact => {
+                contactSelectDropdown[contactSelectDropdown.length] = new Option(contact.contact_name, contact.contact_id);
+            });
+
+        }
+    );
+}

--- a/post.php
+++ b/post.php
@@ -6500,6 +6500,29 @@ if(isset($_POST['merge_ticket'])){
 
 }
 
+if(isset($_POST['change_client_ticket'])){
+
+    validateTechRole();
+
+    $ticket_id = intval($_POST['ticket_id']);
+    $client_id = intval($_POST['new_client_id']);
+    $contact_id = intval($_POST['new_contact_id']);
+
+    // Set any/all existing replies to internal
+    mysqli_query($mysqli, "UPDATE ticket_replies SET ticket_reply_type = 'Internal' WHERE ticket_reply_ticket_id = $ticket_id");
+
+    // Update ticket client & contact
+    mysqli_query($mysqli, "UPDATE tickets SET ticket_client_id = $client_id, ticket_contact_id = $contact_id WHERE ticket_id = $ticket_id LIMIT 1");
+
+    //Logging
+    mysqli_query($mysqli,"INSERT INTO logs SET log_type = 'Ticket Reply', log_action = 'Modify', log_description = '$session_name modified ticket - client changed', log_ip = '$session_ip', log_user_agent = '$session_user_agent', log_client_id = $client_id, log_user_id = $session_user_id, log_entity_id = $ticket_id");
+
+    $_SESSION['alert_message'] = "Ticket client updated";
+
+    header("Location: " . $_SERVER["HTTP_REFERER"]);
+
+}
+
 if(isset($_GET['close_ticket'])){
 
     validateTechRole();

--- a/post.php
+++ b/post.php
@@ -6515,7 +6515,7 @@ if(isset($_POST['change_client_ticket'])){
     mysqli_query($mysqli, "UPDATE tickets SET ticket_client_id = $client_id, ticket_contact_id = $contact_id WHERE ticket_id = $ticket_id LIMIT 1");
 
     //Logging
-    mysqli_query($mysqli,"INSERT INTO logs SET log_type = 'Ticket Reply', log_action = 'Modify', log_description = '$session_name modified ticket - client changed', log_ip = '$session_ip', log_user_agent = '$session_user_agent', log_client_id = $client_id, log_user_id = $session_user_id, log_entity_id = $ticket_id");
+    mysqli_query($mysqli, "INSERT INTO logs SET log_type = 'Ticket Reply', log_action = 'Modify', log_description = '$session_name modified ticket - client changed', log_ip = '$session_ip', log_user_agent = '$session_user_agent', log_client_id = $client_id, log_user_id = $session_user_id, log_entity_id = $ticket_id");
 
     $_SESSION['alert_message'] = "Ticket client updated";
 

--- a/ticket.php
+++ b/ticket.php
@@ -233,6 +233,9 @@ if (isset($_GET['ticket_id'])) {
                             <a class="dropdown-item" href="#" data-toggle="modal" data-target="#mergeTicketModal<?php echo $ticket_id; ?>">
                                 <i class="fas fa-fw fa-clone mr-2"></i>Merge
                             </a>
+                            <a class="dropdown-item" href="#" data-toggle="modal" id="clientChangeTicketModalLoad" data-target="#clientChangeTicketModal">
+                                <i class="fas fa-fw fa-people-carry mr-2"></i>Change Client
+                            </a>
                             <?php if ($session_user_role == 3) { ?>
                                 <div class="dropdown-divider"></div>
                                 <a class="dropdown-item text-danger text-bold" href="post.php?delete_ticket=<?php echo $ticket_id; ?>">
@@ -265,7 +268,7 @@ if (isset($_GET['ticket_id'])) {
                 <?php if ($ticket_status != "Closed") { ?>
                     <form class="mb-3" action="post.php" method="post" autocomplete="off">
                         <input type="hidden" name="ticket_id" id="ticket_id" value="<?php echo $ticket_id; ?>">
-                        <input type="hidden" name="client_id" value="<?php echo $client_id; ?>">
+                        <input type="hidden" name="client_id" id="client_id" value="<?php echo $client_id; ?>">
                         <div class="form-group">
                             <textarea class="form-control summernote" name="ticket_reply" placeholder="Type a response" required></textarea>
                         </div>
@@ -647,6 +650,7 @@ if (isset($_GET['ticket_id'])) {
 
         <?php
         require("ticket_edit_modal.php");
+        require("ticket_change_client_modal.php");
         require("ticket_merge_modal.php");
         require("ticket_invoice_add_modal.php");
 

--- a/ticket.php
+++ b/ticket.php
@@ -651,10 +651,10 @@ if (isset($_GET['ticket_id'])) {
         </div>
 
         <?php
-        require("ticket_edit_modal.php");
-        require("ticket_change_client_modal.php");
-        require("ticket_merge_modal.php");
-        require("ticket_invoice_add_modal.php");
+        require_once("ticket_edit_modal.php");
+        require_once("ticket_change_client_modal.php");
+        require_once("ticket_merge_modal.php");
+        require_once("ticket_invoice_add_modal.php");
 
     }
 

--- a/ticket.php
+++ b/ticket.php
@@ -119,11 +119,13 @@ if (isset($_GET['ticket_id'])) {
         $location_zip = htmlentities($row['location_zip']);
         $location_phone = formatPhoneNumber($row['location_phone']);
 
+        //  REMOVING - doesn't work properly now that a ticket might be created by an agent or client
+        //   Moving to ticket_source in future
         //Ticket Created By
-        $ticket_created_by = intval($row['ticket_created_by']);
-        $ticket_created_by_sql = mysqli_query($mysqli, "SELECT user_name FROM users WHERE user_id = $ticket_created_by");
-        $row = mysqli_fetch_array($ticket_created_by_sql);
-        $ticket_created_by_display = htmlentities($row['user_name']);
+        //$ticket_created_by = intval($row['ticket_created_by']);
+        //$ticket_created_by_sql = mysqli_query($mysqli, "SELECT user_name FROM users WHERE user_id = $ticket_created_by");
+        //$row = mysqli_fetch_array($ticket_created_by_sql);
+        //$ticket_created_by_display = htmlentities($row['user_name']);
 
         if ($contact_id) {
             //Get Contact Ticket Stats
@@ -471,7 +473,7 @@ if (isset($_GET['ticket_id'])) {
                     <div class="ml-1"><i class="fa fa-fw fa-thermometer-half text-secondary mr-2 mb-2"></i><?php echo $ticket_priority_display; ?></div>
                     <div class="ml-1"><i class="fa fa-fw fa-calendar text-secondary mr-2 mb-2"></i>Created: <?php echo $ticket_created_at; ?></div>
                     <div class="ml-1"><i class="fa fa-fw fa-history text-secondary mr-2 mb-2"></i>Updated: <strong><?php echo $ticket_updated_at; ?></strong></div>
-                    <div class="ml-1"><i class="fa fa-fw fa-user text-secondary mr-2 mb-2"></i>Created by: <?php echo $ticket_created_by_display; ?></div>
+                    <!--<div class="ml-1"><i class="fa fa-fw fa-user text-secondary mr-2 mb-2"></i>Created by: <?php // echo $ticket_created_by_display; ?></div>-->
                     <?php
                     if ($ticket_status == "Closed") {
                         $sql_closed_by = mysqli_query($mysqli, "SELECT * FROM tickets, users WHERE ticket_closed_by = user_id");

--- a/ticket_change_client_modal.php
+++ b/ticket_change_client_modal.php
@@ -23,12 +23,12 @@
                     </div>
 
                     <div class="form-group">
-                        <label>New Contact <strong class="text-danger">*</strong></label>
+                        <label>New Contact</label>
                         <div class="input-group">
                             <div class="input-group-prepend">
                                 <span class="input-group-text"><i class="fa fa-fw fa-user"></i></span>
                             </div>
-                            <select class="form-control select2" name="new_contact_id" id="changeContactSelect" required>
+                            <select class="form-control select2" name="new_contact_id" id="changeContactSelect">
                             </select>
                         </div>
                     </div>

--- a/ticket_change_client_modal.php
+++ b/ticket_change_client_modal.php
@@ -1,0 +1,49 @@
+<div class="modal" id="clientChangeTicketModal" tabindex="-1">
+    <div class="modal-dialog modal-md">
+        <div class="modal-content bg-dark">
+            <div class="modal-header">
+                <h5 class="modal-title"><i class="fa fa-fw fa-people-carry mr-2"></i>Change <?php echo "$ticket_prefix$ticket_number"; ?> to another client</h5>
+                <button type="button" class="close text-white" data-dismiss="modal">
+                    <span>&times;</span>
+                </button>
+            </div>
+            <form action="post.php" method="post" autocomplete="off">
+                <input type="hidden" name="ticket_id" value="<?php echo $ticket_id; ?>">
+                <div class="modal-body bg-white">
+
+                    <div class="form-group">
+                        <label>New Client <strong class="text-danger">*</strong></label>
+                        <div class="input-group">
+                            <div class="input-group-prepend">
+                                <span class="input-group-text"><i class="fa fa-fw fa-users"></i></span>
+                            </div>
+                            <select class="form-control select2" name="new_client_id" id="changeClientSelect" required>
+                            </select>
+                        </div>
+                    </div>
+
+                    <div class="form-group">
+                        <label>New Contact <strong class="text-danger">*</strong></label>
+                        <div class="input-group">
+                            <div class="input-group-prepend">
+                                <span class="input-group-text"><i class="fa fa-fw fa-user"></i></span>
+                            </div>
+                            <select class="form-control select2" name="new_contact_id" id="changeContactSelect" required>
+                            </select>
+                        </div>
+                    </div>
+
+                </div>
+                <div class="modal-footer bg-white">
+                    <button type="submit" name="change_client_ticket" class="btn btn-primary text-bold"><i class="fa fa-check mr-2"></i>Change</button>
+                    <button type="button" class="btn btn-light" data-dismiss="modal"><i class="fa fa-times mr-2"></i>Cancel</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+<!-- Ticket Change Client JS -->
+<link rel="stylesheet" href="plugins/jquery-ui/jquery-ui.min.css">
+<script src="plugins/jquery-ui/jquery-ui.min.js"></script>
+<script src="js/ticket_change_client.js"></script>


### PR DESCRIPTION
This PR adds the ability to change a ticket's client

![image](https://user-images.githubusercontent.com/32306651/230962054-078ddd0b-3c4b-4a5e-b027-9ccb2b96696d.png)

Additionally we're adding a new database field: `ticket_source` and will soon retire `ticket_created_by`. 
- Ticket source will show where a ticket was raised from: an agent, the portal, via email, scheduled ticket, etc. Once this is implemented across the code base, we could also report on it to show the breakdown of where your tickets are raised (#514).
- Ticket created by was originally designed when contacts were considered users.  It quickly became clear that it was better to separate contacts and users, meaning there is now no way to differentiate whether the value in ticket_created_by is a user or contact. Given that we track a tickets assigned agent and client contact, and log all tickets raised, it seems safe to remove this field - for the sake of simplicity.