### PR TITLE
Email ticket attachments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,9 +11,8 @@ uploads/users/*
 !uploads/users/index.php
 uploads/tmp/*
 !uploads/tmp/index.php
-backups/*
-!backups/index.php
-!backups/.htaccess
+uploads/tickets/*
+!uploads/tickets/index.php
 .idea/*
 plugins/htmlpurifier/standalone/HTMLPurifier/DefinitionCache/Serializer/HTML/*
 plugins/htmlpurifier/standalone/HTMLPurifier/DefinitionCache/Serializer/URI/*

--- a/database_updates.php
+++ b/database_updates.php
@@ -947,17 +947,33 @@ if (LATEST_DATABASE_VERSION > CURRENT_DATABASE_VERSION) {
     }
 
     if (CURRENT_DATABASE_VERSION == '0.4.9') {
-    // Insert queries here required to update to DB version 0.5.0
+        // Insert queries here required to update to DB version 0.5.0
         mysqli_query($mysqli, "ALTER TABLE `clients` ADD `client_tax_id_number` VARCHAR(255) NULL DEFAULT NULL AFTER `client_net_terms`");
-    // Then, update the database to the next sequential version
+        // Then, update the database to the next sequential version
         mysqli_query($mysqli, "UPDATE `settings` SET `config_current_database_version` = '0.5.0'");
     }
 
-    //if (CURRENT_DATABASE_VERSION == '0.5.0') {
-    // Insert queries here required to update to DB version 0.5.1
+    if (CURRENT_DATABASE_VERSION == '0.5.0') {
+        // Insert queries here required to update to DB version 0.5.1
+        mysqli_query($mysqli, "CREATE TABLE `ticket_attachments` (
+          `ticket_attachment_id` int(11) NOT NULL AUTO_INCREMENT,
+          `ticket_attachment_name` varchar(255) NOT NULL,
+          `ticket_attachment_reference_name` varchar(255) NOT NULL,
+          `ticket_attachment_created_at` datetime NOT NULL DEFAULT current_timestamp(),
+          `ticket_attachment_ticket_id` int(11) NOT NULL,
+          `ticket_attachment_reply_id` int(11) DEFAULT NULL,
+          PRIMARY KEY (`ticket_attachment_id`)
+        )");
+
+        // Then, update the database to the next sequential version
+        mysqli_query($mysqli, "UPDATE `settings` SET `config_current_database_version` = '0.5.1'");
+    }
+
+    //if (CURRENT_DATABASE_VERSION == '0.5.1') {
+    // Insert queries here required to update to DB version 0.5.2
 
     // Then, update the database to the next sequential version
-    // mysqli_query($mysqli, "UPDATE `settings` SET `config_current_database_version` = '0.5.1'");
+    // mysqli_query($mysqli, "UPDATE `settings` SET `config_current_database_version` = '0.5.2'");
     //}
 
 } else {

--- a/database_version.php
+++ b/database_version.php
@@ -5,4 +5,4 @@
  * It is used in conjunction with database_updates.php
  */
 
-DEFINE("LATEST_DATABASE_VERSION", "0.5.0");
+DEFINE("LATEST_DATABASE_VERSION", "0.5.1");

--- a/db.sql
+++ b/db.sql
@@ -1305,6 +1305,20 @@ CREATE TABLE `tickets` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
+-- Table structure for table `ticket_attachments`
+--
+
+CREATE TABLE `ticket_attachments` (
+  `ticket_attachment_id` int(11) NOT NULL AUTO_INCREMENT,
+  `ticket_attachment_name` varchar(255) NOT NULL,
+  `ticket_attachment_reference_name` varchar(255) NOT NULL,
+  `ticket_attachment_created_at` datetime NOT NULL DEFAULT current_timestamp(),
+  `ticket_attachment_ticket_id` int(11) NOT NULL,
+  `ticket_attachment_reply_id` int(11) DEFAULT NULL,
+  PRIMARY KEY (`ticket_attachment_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+--
 -- Table structure for table `transfers`
 --
 


### PR DESCRIPTION
This PR adds support for parsing attachments on tickets raised/updated via email.

- Attachments are stored at uploads/tickets/[ticket-id]/
- Attachment metadata is stored in the ticket_attachments table
- Attachments are shown just under the ticket / ticket reply

Future work:
- Show attachments in the client portal
- Allow attaching files in both the admin and client portals