### PR TITLE
Fixed clients.php blank page

### DIFF
--- a/clients.php
+++ b/clients.php
@@ -20,7 +20,7 @@ $sql = mysqli_query(
     OR contact_mobile LIKE '%$phone_query%' OR location_address LIKE '%$q%' OR location_city LIKE '%$q%' OR location_state LIKE '%$q%' OR location_zip LIKE '%$q%' OR tag_name LIKE '%$q%' OR client_tax_id_number LIKE '%$q%')
     AND client_archived_at IS NULL
     AND DATE(client_created_at) BETWEEN '$dtf' AND '$dtt'
-    GROUP BY clients.client_id
+    GROUP BY clients.client_id, client_tags.client_tag_tag_id
     ORDER BY $sb $o LIMIT $record_from, $record_to
 ");
 

--- a/clients.php
+++ b/clients.php
@@ -11,17 +11,23 @@ $url_query_strings_sb = http_build_query(array_merge($_GET, array('sb' => $sb, '
 
 $sql = mysqli_query(
     $mysqli,
-    "SELECT DISTINCT SQL_CALC_FOUND_ROWS * FROM clients
-    LEFT JOIN contacts ON clients.primary_contact = contacts.contact_id AND contact_archived_at IS NULL
-    LEFT JOIN locations ON clients.primary_location = locations.location_id AND location_archived_at IS NULL
-    LEFT JOIN client_tags ON client_tags.client_tag_client_id = clients.client_id
-    LEFT JOIN tags ON tags.tag_id = client_tags.client_tag_tag_id
-    WHERE (client_name LIKE '%$q%' OR client_type LIKE '%$q%' OR client_referral LIKE '%$q%' OR contact_email LIKE '%$q%' OR contact_name LIKE '%$q%' OR contact_phone LIKE '%$phone_query%'
-    OR contact_mobile LIKE '%$phone_query%' OR location_address LIKE '%$q%' OR location_city LIKE '%$q%' OR location_state LIKE '%$q%' OR location_zip LIKE '%$q%' OR tag_name LIKE '%$q%' OR client_tax_id_number LIKE '%$q%')
-    AND client_archived_at IS NULL
-    AND DATE(client_created_at) BETWEEN '$dtf' AND '$dtt'
-    GROUP BY clients.client_id, client_tags.client_tag_tag_id
-    ORDER BY $sb $o LIMIT $record_from, $record_to
+    "
+SELECT SQL_CALC_FOUND_ROWS clients.*, contacts.*, locations.*, GROUP_CONCAT(tags.tag_name) AS tag_names
+FROM clients
+LEFT JOIN contacts ON clients.primary_contact = contacts.contact_id AND contacts.contact_archived_at IS NULL
+LEFT JOIN locations ON clients.primary_location = locations.location_id AND locations.location_archived_at IS NULL
+LEFT JOIN client_tags ON client_tags.client_tag_client_id = clients.client_id
+LEFT JOIN tags ON tags.tag_id = client_tags.client_tag_tag_id
+WHERE (clients.client_name LIKE '%$q%' OR clients.client_type LIKE '%$q%' OR clients.client_referral LIKE '%$q%'
+       OR contacts.contact_email LIKE '%$q%' OR contacts.contact_name LIKE '%$q%' OR contacts.contact_phone LIKE '%$phone_query%'
+       OR contacts.contact_mobile LIKE '%$phone_query%' OR locations.location_address LIKE '%$q%'
+       OR locations.location_city LIKE '%$q%' OR locations.location_state LIKE '%$q%' OR locations.location_zip LIKE '%$q%'
+       OR tags.tag_name LIKE '%$q%' OR clients.client_tax_id_number LIKE '%$q%')
+  AND clients.client_archived_at IS NULL
+  AND DATE(clients.client_created_at) BETWEEN '$dtf' AND '$dtt'
+GROUP BY clients.client_id
+ORDER BY $sb $o
+LIMIT $record_from, $record_to
 ");
 
 $num_rows = mysqli_fetch_row(mysqli_query($mysqli, "SELECT FOUND_ROWS()"));


### PR DESCRIPTION
# Issue

On a fresh install (from today) of ITFlow, I could not figure out how to add a client. It turned out that there was a MySQL error caused from a query in the `clients.php` files.

Here is a screenshot of the problem with PHP error reporting enabled:

[![before.jpg](https://i.postimg.cc/FRRx1gWs/before.jpg)](https://postimg.cc/d7bCxdcz)

# Fix

I fixed this by by adding `client_tags.client_tag_tag_id` to the `GROUP BY` portion of the query. I believe you could also fix the error with this MySQL query: `SET GLOBAL sql_mode=(SELECT REPLACE(@@sql_mode,'ONLY_FULL_GROUP_BY',''));`. However, I felt it was better to modify the original query than set a global variable.

# Testing

The modification in created in this pull request fixed the issue. I was then able to create a client, create a tag, add a tag to a client, and modify the client information afterwards. Since I did not modify the query in any fundamental way, I do not believe it would cause break any other part of the code.

[![after.jpg](https://i.postimg.cc/sxC9Kdf1/after.jpg)](https://postimg.cc/dknytfyK)