### PR TITLE
Add function to use htmlentities without deprecated error

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -45,6 +45,10 @@ function key32gen()
     return $key;
 }
 
+function nullable_htmlentities($unsanitizedInput) {
+    return htmlentities($unsanitizedInput ?? '');
+}
+
 function initials($str) {
     if (!empty($str)) {
         $ret = '';


### PR DESCRIPTION
# Issue
PHP 8.1+ gives errors about `htmlentities()` if null is provided as the argument. This pull request will make it easy to solve issue https://github.com/itflow-org/itflow/issues/591.

Here is an example of clients.php using `htmlentities()` with error reporting on:

[![image.png](https://i.postimg.cc/4dFShgY4/image.png)](https://postimg.cc/2bhwPgdg)

# Fix

This pull request creates a function called `nullable_htmlentities()` in functions.php.  The function is the same as `htmlentities()`, however it will replace null values with any empty string.

I believe this function is the best method of fixing the deprecation error because it is easier to CTRL + R and replace all instances of `htmlentities()` than it is to manually add `?? ''` to each argument in all instances of `htmlentities()`.

Here is an example of clients.php using `nullable_htmlentities()` with error reporting on:

![image](https://github.com/itflow-org/itflow/assets/91496127/586b5534-aae4-4a2a-99ec-2c7f7af86abc)

Please note that this pull request only includes the function, and does not replace any `htmlentities()` functions in the codebase.
