### PR TITLE
Add database structure for 'login key' protection concept

### DIFF
--- a/database_updates.php
+++ b/database_updates.php
@@ -1054,11 +1054,17 @@ if (LATEST_DATABASE_VERSION > CURRENT_DATABASE_VERSION) {
         mysqli_query($mysqli, "UPDATE `settings` SET `config_current_database_version` = '0.5.5'");
     }
 
-    //if (CURRENT_DATABASE_VERSION == '0.5.5') {
-        //Insert queries here required to update to DB version 0.5.6
+    if (CURRENT_DATABASE_VERSION == '0.5.5') {
+        mysqli_query($mysqli, "ALTER TABLE `settings` ADD `config_login_key_required` TINYINT(1) NOT NULL DEFAULT '0' AFTER `config_module_enable_accounting`, ADD `config_login_key_secret` VARCHAR(255) NULL DEFAULT NULL AFTER `config_login_key_required`; ");
 
-        // Then, update the database to the next sequential version
-        //mysqli_query($mysqli, "UPDATE `settings` SET `config_current_database_version` = '0.5.6'");
+        mysqli_query($mysqli, "UPDATE `settings` SET `config_current_database_version` = '0.5.6'");
+    }
+
+    //if (CURRENT_DATABASE_VERSION == '0.5.6') {
+    //Insert queries here required to update to DB version 0.5.7
+
+    // Then, update the database to the next sequential version
+    //mysqli_query($mysqli, "UPDATE `settings` SET `config_current_database_version` = '0.5.7'");
     //}
 
 } else {

--- a/database_version.php
+++ b/database_version.php
@@ -5,4 +5,4 @@
  * It is used in conjunction with database_updates.php
  */
 
-DEFINE("LATEST_DATABASE_VERSION", "0.5.5");
+DEFINE("LATEST_DATABASE_VERSION", "0.5.6");

--- a/db.sql
+++ b/db.sql
@@ -1138,6 +1138,8 @@ CREATE TABLE `settings` (
   `config_theme` varchar(200) DEFAULT 'blue',
   `config_telemetry` tinyint(1) DEFAULT 0,
   `config_timezone` varchar(200) NOT NULL DEFAULT 'America/New_York',
+  `config_login_key_required` tinyint(1) NOT NULL DEFAULT 0,
+  `config_login_key_secret` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`company_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;

--- a/get_settings.php
+++ b/get_settings.php
@@ -83,6 +83,10 @@ $config_module_enable_itdoc = intval($row['config_module_enable_itdoc']);
 $config_module_enable_ticketing = intval($row['config_module_enable_ticketing']);
 $config_module_enable_accounting = intval($row['config_module_enable_accounting']);
 
+// Login key
+$config_login_key_required = $row['config_login_key_required'];
+$config_login_key_secret = $row['config_login_key_secret'];
+
 // Currency
 $config_currency_format = "US_en";
 

--- a/login.php
+++ b/login.php
@@ -29,7 +29,7 @@ if ($failed_login_count >= 15) {
     exit("<h2>$config_app_name</h2>Your IP address has been blocked due to repeated failed login attempts. Please try again later. <br><br>This action has been logged.");
 }
 
-// Query Settings for "default" company (as companies are being removed shortly)
+// Query Settings for company
 $sql_settings = mysqli_query($mysqli, "SELECT * FROM settings LEFT JOIN companies ON settings.company_id = companies.company_id WHERE settings.company_id = 1");
 $row = mysqli_fetch_array($sql_settings);
 
@@ -45,6 +45,19 @@ $config_smtp_username = $row['config_smtp_username'];
 $config_smtp_password = $row['config_smtp_password'];
 $config_mail_from_email = $row['config_mail_from_email'];
 $config_mail_from_name = $row['config_mail_from_name'];
+
+//// Login key (if setup)
+//$config_login_key_required = $row['config_login_key_required'];
+//$config_login_key_secret = $row['config_login_key_secret'];
+//
+//// Login key verification
+////  If no/incorrect 'key' is supplied, send to client portal instead
+//if ($config_login_key_required) {
+//    if (!isset($_GET['key']) || $_GET['key'] !== $config_login_key_secret) {
+//        header("Location: portal");
+//        exit();
+//    }
+//}
 
 // HTTP-Only cookies
 ini_set("session.cookie_httponly", true);
@@ -255,6 +268,8 @@ if (isset($_POST['login'])) {
         <div class="card-body login-card-body">
             <p class="login-box-msg"><?php if (isset($response)) { echo $response; } ?></p>
             <form method="post">
+
+
                 <div class="input-group mb-3" <?php if (isset($token_field)) { echo "hidden"; } ?>>
                     <input type="text" class="form-control" placeholder="Agent Email" name="email" value="<?php if (isset($token_field)) { echo $email; }?>" required <?php if (!isset($token_field)) { echo "autofocus"; } ?> >
                     <div class="input-group-append">

--- a/post.php
+++ b/post.php
@@ -839,6 +839,22 @@ if(isset($_POST['edit_module_settings'])){
 
 }
 
+if(isset($_POST['edit_security_settings'])){
+    validateAdminRole();
+
+    $config_login_key_required = intval($_POST['config_login_key_required']);
+    $config_login_key_secret = sanitizeInput($_POST['config_login_key_secret']);
+
+    mysqli_query($mysqli,"UPDATE settings SET config_login_key_required = '$config_login_key_required', config_login_key_secret = '$config_login_key_secret' WHERE company_id = 1");
+
+    // Logging
+    mysqli_query($mysqli,"INSERT INTO logs SET log_type = 'Settings', log_action = 'Modify', log_description = '$session_name modified login key settings', log_ip = '$session_ip', log_user_agent = '$session_user_agent', log_user_id = $session_user_id");
+
+    $_SESSION['alert_message'] = "Login key settings updated";
+
+    header("Location: " . $_SERVER["HTTP_REFERER"]);
+}
+
 if(isset($_POST['edit_telemetry_settings'])){
 
     validateAdminRole();
@@ -9280,7 +9296,7 @@ if(isset($_GET['logout'])){
     session_unset();
     session_destroy();
 
-    header('Location: login.php');
+    header('Location: login.php?key=' . $config_login_key_secret);
 }
 
 ?>

--- a/settings_security.php
+++ b/settings_security.php
@@ -1,0 +1,38 @@
+<?php
+require_once("inc_all_settings.php");
+?>
+
+    <div class="card card-dark">
+        <div class="card-header py-3">
+            <h3 class="card-title"><i class="fas fa-fw fa-shield-alt mr-2"></i>Security</h3>
+        </div>
+        <div class="card-body">
+            <form action="post.php" method="post" autocomplete="off">
+
+                <div class="form-group">
+                    <div class="custom-control custom-switch">
+                        <input type="checkbox" class="custom-control-input" name="config_login_key_required" <?php if ($config_login_key_required == 1) { echo "checked"; } ?> value="1" id="customSwitch1">
+                        <label class="custom-control-label" for="customSwitch1">Require a login key to protect the technician login page?</label>
+                    </div>
+                </div>
+
+                <div class="form-group">
+                    <label>Login key secret value <small class="text-secondary">(This must be provided in the URL as /login.php?key=<?php echo htmlentities($config_login_key_secret)?>)</small></label>
+                    <div class="input-group">
+                        <div class="input-group-prepend">
+                            <span class="input-group-text"><i class="fa fa-fw fa-key"></i></span>
+                        </div>
+                        <input type="text" class="form-control" name="config_login_key_secret" required pattern="\w{3,99}" placeholder="Something really easy for techs to remember: e.g. MYSECRET" value="<?php echo htmlentities($config_login_key_secret); ?>">
+                    </div>
+                </div>
+
+                <hr>
+
+                <button type="submit" name="edit_security_settings" class="btn btn-primary text-bold"><i class="fas fa-check mr-2"></i>Save</button>
+
+            </form>
+        </div>
+    </div>
+
+<?php
+require_once("footer.php");

--- a/settings_side_nav.php
+++ b/settings_side_nav.php
@@ -33,6 +33,14 @@
           </a>
         </li>
 
+<!--        <li class="nav-item">-->
+<!--          <a class="nav-link --><?php //if (basename($_SERVER["PHP_SELF"]) == "settings_security.php") { echo "active"; } ?><!--"-->
+<!--             href="settings_security.php">-->
+<!--            <i class="nav-icon fas fa-shield-alt"></i>-->
+<!--            <p>Security</p>-->
+<!--          </a>-->
+<!--        </li>-->
+
         <li class="nav-header mt-3">TAGS & CATEGORIES</li>
 
         <li class="nav-item">


### PR DESCRIPTION
The 'login key' concept is inspired by both [this](https://old.reddit.com/r/MeshCentral/comments/ob8o2w/howto_a_paranoid_guys_guide_to_protecting/) reddit post around a 'paranoid' protection of MeshCentral, and my experience with Wordpress plugins that move the login page from /wp-admin to help protect against automated bot attacks.

The idea is that to even access ITFlow's main/technical login page, you need to know and supply a shared key/secret in the GET query string as 'key'. This is entirely optional, but is an easy way to add a little extra protection to your ITFlow instance.

You'll be able to turn this on & set your key in the admin settings. 
For example, if your key was `pineapple`, you would need to access/bookmark the URL `https://demo.itflow.org/login.php?key=pineapple` to get to the login page. Otherwise, you just get redirected to the client portal.

This PR only adds the structure, we'll un-comment the code to make this available in a few days.