### PR TITLE
Security enchancement for getIP() function

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -85,6 +85,9 @@ function getIP() {
     } else {
         $ip = $_SERVER["HTTP_CF_CONNECTING_IP"] ?? $_SERVER['REMOTE_ADDR'];
     }
+    
+    if (!filter_var($ip, FILTER_VALIDATE_IP))
+        die("Potential Security Violation");
 
     return $ip;
 }


### PR DESCRIPTION
A few days ago I probed at my self-hosted instance of ITFlow looking for security issues. 

One of the extremely minor things that I noticed is that the IP address is not verified to be valid before being inserted into the database and it is possible to insert strings into the IP column. This is currently a non-issue and I could not find a way to take advantage of this (attempted XSS and SQL injection).

This pull request will ensure the IP address is valid and respond with `die("Potential Security Violation");` if it is invalid. 
Please let me know if you would like me to modify this response.

I want to re-iterate that there is no current vulnerability that is being patched with this. It is simply an extra security measure to create [defense in depth](https://en.wikipedia.org/wiki/Defense_in_depth_(computing)).

My testing with 10 valid IPv4 addresses, 10 valid IPv6 addresses, and 10 mixed addresses (valid, invalid, IPv4, and IPv6):
https://3v4l.org/1SaZC