### PR TITLE
Add regex to remove http:// or https:// from client_website

### DIFF
--- a/models/client.php
+++ b/models/client.php
@@ -1,7 +1,7 @@
 <?php
 $name = sanitizeInput($_POST['name']);
 $type = sanitizeInput($_POST['type']);
-$website = sanitizeInput($_POST['website']);
+$website = preg_replace("(^https?://)", "", sanitizeInput($_POST['website']));
 $referral = sanitizeInput($_POST['referral']);
 $rate = floatval($_POST['rate']);
 $currency_code = sanitizeInput($_POST['currency_code']);


### PR DESCRIPTION
Issue #684

We only expect a domain in this field (e.g. example.com) but allow https://example.com. This breaks the link on the client banner and ticket parsing based on domain.