### PR TITLE
Enable login key code

### DIFF
--- a/login.php
+++ b/login.php
@@ -46,18 +46,18 @@ $config_smtp_password = $row['config_smtp_password'];
 $config_mail_from_email = $row['config_mail_from_email'];
 $config_mail_from_name = $row['config_mail_from_name'];
 
-//// Login key (if setup)
-//$config_login_key_required = $row['config_login_key_required'];
-//$config_login_key_secret = $row['config_login_key_secret'];
-//
-//// Login key verification
-////  If no/incorrect 'key' is supplied, send to client portal instead
-//if ($config_login_key_required) {
-//    if (!isset($_GET['key']) || $_GET['key'] !== $config_login_key_secret) {
-//        header("Location: portal");
-//        exit();
-//    }
-//}
+// Login key (if setup)
+$config_login_key_required = $row['config_login_key_required'];
+$config_login_key_secret = $row['config_login_key_secret'];
+
+// Login key verification
+//  If no/incorrect 'key' is supplied, send to client portal instead
+if ($config_login_key_required) {
+    if (!isset($_GET['key']) || $_GET['key'] !== $config_login_key_secret) {
+        header("Location: portal");
+        exit();
+    }
+}
 
 // HTTP-Only cookies
 ini_set("session.cookie_httponly", true);

--- a/settings_security.php
+++ b/settings_security.php
@@ -12,7 +12,7 @@ require_once("inc_all_settings.php");
                 <div class="form-group">
                     <div class="custom-control custom-switch">
                         <input type="checkbox" class="custom-control-input" name="config_login_key_required" <?php if ($config_login_key_required == 1) { echo "checked"; } ?> value="1" id="customSwitch1">
-                        <label class="custom-control-label" for="customSwitch1">Require a login key to protect the technician login page?</label>
+                        <label class="custom-control-label" for="customSwitch1">Require a login key to access the technician login page?</label>
                     </div>
                 </div>
 

--- a/settings_side_nav.php
+++ b/settings_side_nav.php
@@ -33,13 +33,13 @@
           </a>
         </li>
 
-<!--        <li class="nav-item">-->
-<!--          <a class="nav-link --><?php //if (basename($_SERVER["PHP_SELF"]) == "settings_security.php") { echo "active"; } ?><!--"-->
-<!--             href="settings_security.php">-->
-<!--            <i class="nav-icon fas fa-shield-alt"></i>-->
-<!--            <p>Security</p>-->
-<!--          </a>-->
-<!--        </li>-->
+        <li class="nav-item">
+          <a class="nav-link <?php if (basename($_SERVER["PHP_SELF"]) == "settings_security.php") { echo "active"; } ?>"
+             href="settings_security.php">
+            <i class="nav-icon fas fa-shield-alt"></i>
+            <p>Security</p>
+          </a>
+        </li>
 
         <li class="nav-header mt-3">TAGS & CATEGORIES</li>
 


### PR DESCRIPTION
_Related to #680_

This is an optional feature.

When enabled (Settings > Security), you are required to provide your chosen key in the URL like `demo.example.com/login.php?key=mykey` in order to access the login page. 
This adds a little additional security to the login page, and allows a smooth transition for users to get to the client portal.

Behaviour:
- Login key disabled: Nothing changes (default)
- Login key enabled & correctly provided in URL: Login page is shown as normal
- Login key enabled & not provided/incorrect: Browser redirects to the client portal login page