### PR TITLE
Ticket parser: Better handle clients replying to closed tickets

### DIFF
--- a/cron_ticket_email_parser.php
+++ b/cron_ticket_email_parser.php
@@ -7,7 +7,6 @@
 /*
 TODO:
   - Process unregistered contacts/clients into an inbox to allow a ticket to be created/ignored
-  - Better handle replying to closed tickets
   - Support for authenticating with OAuth
   - Separate Mailbox Account for tickets 2022-12-14 - JQ
 
@@ -22,6 +21,12 @@ require_once("functions.php");
 
 // Get settings for the "default" company
 require_once("get_settings.php");
+
+// Get company name & phone
+$sql = mysqli_query($mysqli, "SELECT company_name, company_phone FROM companies WHERE company_id = 1");
+$row = mysqli_fetch_array($sql);
+$company_name = $row['company_name'];
+$company_phone = formatPhoneNumber($row['company_phone']);
 
 // Check setting enabled
 if ($config_ticket_email_parse == 0) {
@@ -65,7 +70,7 @@ $allowed_extensions = array('jpg', 'jpeg', 'gif', 'png', 'webp', 'pdf', 'txt', '
 function addTicket($contact_id, $contact_name, $contact_email, $client_id, $date, $subject, $message, $attachments) {
 
     // Access global variables
-    global $mysqli, $config_ticket_prefix, $config_ticket_client_general_notifications, $config_base_url, $config_ticket_from_name, $config_ticket_from_email, $config_smtp_host, $config_smtp_port, $config_smtp_encryption, $config_smtp_username, $config_smtp_password;
+    global $mysqli, $company_name, $company_phone, $config_ticket_prefix, $config_ticket_client_general_notifications, $config_base_url, $config_ticket_from_name, $config_ticket_from_email, $config_smtp_host, $config_smtp_port, $config_smtp_encryption, $config_smtp_username, $config_smtp_password, $allowed_extensions;
 
     // Get the next Ticket Number and add 1 for the new ticket number
     $ticket_number_sql = mysqli_fetch_array(mysqli_query($mysqli, "SELECT config_ticket_next_number FROM settings WHERE company_id = 1"));
@@ -94,7 +99,6 @@ function addTicket($contact_id, $contact_name, $contact_email, $client_id, $date
         $att_extension = strtolower(end($att_extarr));
 
         // Check the extension is allowed
-        global $allowed_extensions;
         if (in_array($att_extension, $allowed_extensions)) {
 
             // Setup directory for this ticket ID
@@ -118,12 +122,6 @@ function addTicket($contact_id, $contact_name, $contact_email, $client_id, $date
         }
 
     }
-
-    // Get company name & phone
-    $sql = mysqli_query($mysqli, "SELECT company_name, company_phone FROM companies WHERE company_id = 1");
-    $row = mysqli_fetch_array($sql);
-    $company_phone = formatPhoneNumber($row['company_phone']);
-    $company_name = $row['company_name'];
 
 
     // E-mail client notification that ticket has been created
@@ -161,7 +159,7 @@ function addReply($from_email, $date, $subject, $ticket_number, $message, $attac
     // Add email as a comment/reply to an existing ticket
 
     // Access global variables
-    global $mysqli, $config_ticket_prefix, $config_base_url, $config_ticket_from_name, $config_ticket_from_email, $config_smtp_host, $config_smtp_port, $config_smtp_encryption, $config_smtp_username, $config_smtp_password;
+    global $mysqli, $company_name, $company_phone, $config_ticket_prefix, $config_base_url, $config_ticket_from_name, $config_ticket_from_email, $config_smtp_host, $config_smtp_port, $config_smtp_encryption, $config_smtp_username, $config_smtp_password, $allowed_extensions;
 
     // Set default reply type
     $ticket_reply_type = 'Client';
@@ -187,9 +185,27 @@ function addReply($from_email, $date, $subject, $ticket_number, $message, $attac
         $ticket_contact_email = $row['contact_email'];
         $client_id = intval($row['ticket_client_id']);
 
-        // Check ticket isn't closed
+        // Check ticket isn't closed - tickets can't be re-opened
         if ($ticket_status == "Closed") {
             mysqli_query($mysqli, "INSERT INTO notifications SET notification_type = 'Ticket', notification = 'Email parser: $from_email attempted to re-open ticket $config_ticket_prefix$ticket_number (ID $ticket_id) - check inbox manually to see email', notification_client_id = $client_id");
+
+            $email_subject = "Action required: This ticket is already closed";
+            $email_body    = "Hi there, <br><br>You've tried to reply to a ticket that is closed - we won't see your response. <br><br>Please raise a new ticket by sending a fresh e-mail to our support address. <br><br>~<br>$company_name<br>Support Department<br>$config_ticket_from_email<br>$company_phone";
+
+            sendSingleEmail(
+                $config_smtp_host,
+                $config_smtp_username,
+                $config_smtp_password,
+                $config_smtp_encryption,
+                $config_smtp_port,
+                $config_ticket_from_email,
+                $config_ticket_from_name,
+                $from_email,
+                $from_email,
+                $email_subject,
+                $email_body
+            );
+
             return false;
         }
 
@@ -230,7 +246,6 @@ function addReply($from_email, $date, $subject, $ticket_number, $message, $attac
             $att_extension = strtolower(end($att_extarr));
 
             // Check the extension is allowed
-            global $allowed_extensions;
             if (in_array($att_extension, $allowed_extensions)) {
 
                 // Setup directory for this ticket ID


### PR DESCRIPTION
If a client replies to a closed ticket, they get an automatic email back stating they should raise a new ticket instead.