### PR TITLE
Feature update: add credentials for IMAP

### DIFF
--- a/cron_ticket_email_parser.php
+++ b/cron_ticket_email_parser.php
@@ -288,7 +288,7 @@ function addReply($from_email, $date, $subject, $ticket_number, $message, $attac
 $imap_mailbox = "$config_imap_host:$config_imap_port/imap/$config_imap_encryption";
 
 // Connect to host via IMAP
-$imap = imap_open("{{$imap_mailbox}}INBOX", $config_smtp_username, $config_smtp_password);
+$imap = imap_open("{{$imap_mailbox}}INBOX", $config_imap_username, $config_imap_password);
 
 // Check connection
 if (!$imap) {

--- a/database_updates.php
+++ b/database_updates.php
@@ -1134,7 +1134,9 @@ if (LATEST_DATABASE_VERSION > CURRENT_DATABASE_VERSION) {
 
     if (CURRENT_DATABASE_VERSION == '0.6.1') {
         mysqli_query($mysqli, "ALTER TABLE `settings` ADD COLUMN `config_imap_username` VARCHAR(200) NULL DEFAULT NULL AFTER `config_imap_encryption`");
-        mysqli_query($mysqli, "ALTER TABLE `settings` ADD COLUMN `config_imap_password` VARCHAR(200) NULL DEFAULT NULL AFTER `config_imap_username`;");
+        mysqli_query($mysqli, "ALTER TABLE `settings` ADD COLUMN `config_imap_password` VARCHAR(200) NULL DEFAULT NULL AFTER `config_imap_username`");
+
+        mysqli_query($mysqli, "UPDATE `settings` SET `config_current_database_version` = '0.6.2'");
     }
 
     //if (CURRENT_DATABASE_VERSION == '0.6.2') {

--- a/database_updates.php
+++ b/database_updates.php
@@ -1132,7 +1132,12 @@ if (LATEST_DATABASE_VERSION > CURRENT_DATABASE_VERSION) {
         mysqli_query($mysqli, "UPDATE `settings` SET `config_current_database_version` = '0.6.1'");
     }
 
-    //if (CURRENT_DATABASE_VERSION == '0.6.1') {
+    if (CURRENT_DATABASE_VERSION == '0.6.1') {
+        mysqli_query($mysqli, "ALTER TABLE `settings` ADD COLUMN `config_imap_username` VARCHAR(200) NULL DEFAULT NULL AFTER `config_imap_encryption`");
+        mysqli_query($mysqli, "ALTER TABLE `settings` ADD COLUMN `config_imap_password` VARCHAR(200) NULL DEFAULT NULL AFTER `config_imap_username`;");
+    }
+
+    //if (CURRENT_DATABASE_VERSION == '0.6.2') {
         //Insert queries here required to update to DB version 0.6.2
 
         // Then, update the database to the next sequential version

--- a/database_version.php
+++ b/database_version.php
@@ -5,4 +5,4 @@
  * It is used in conjunction with database_updates.php
  */
 
-DEFINE("LATEST_DATABASE_VERSION", "0.6.1");
+DEFINE("LATEST_DATABASE_VERSION", "0.6.2");

--- a/db.sql
+++ b/db.sql
@@ -1119,6 +1119,8 @@ CREATE TABLE `settings` (
   `config_imap_host` varchar(200) DEFAULT NULL,
   `config_imap_port` int(5) DEFAULT NULL,
   `config_imap_encryption` varchar(200) DEFAULT NULL,
+  `config_imap_username` varchar(200) DEFAULT NULL,
+  `config_imap_password` varchar(200) DEFAULT NULL,
   `config_default_transfer_from_account` int(11) DEFAULT NULL,
   `config_default_transfer_to_account` int(11) DEFAULT NULL,
   `config_default_payment_account` int(11) DEFAULT NULL,

--- a/get_settings.php
+++ b/get_settings.php
@@ -23,6 +23,8 @@ $config_mail_from_name = $row['config_mail_from_name'];
 $config_imap_host = $row['config_imap_host'];
 $config_imap_port = intval($row['config_imap_port']);
 $config_imap_encryption = $row['config_imap_encryption'];
+$config_imap_username = $row['config_imap_username'];
+$config_imap_password = $row['config_imap_password'];
 
 // Defaults
 $config_default_transfer_from_account = intval($row['config_default_transfer_from_account']);

--- a/post/setting.php
+++ b/post/setting.php
@@ -62,10 +62,12 @@ if (isset($_POST['edit_mail_settings'])) {
     $config_mail_from_email = sanitizeInput($_POST['config_mail_from_email']);
     $config_mail_from_name = sanitizeInput($_POST['config_mail_from_name']);
     $config_imap_host = sanitizeInput($_POST['config_imap_host']);
+    $config_imap_username = sanitizeInput($_POST['config_imap_username']);
+    $config_imap_password = sanitizeInput($_POST['config_imap_password']);
     $config_imap_port = intval($_POST['config_imap_port']);
     $config_imap_encryption = sanitizeInput($_POST['config_imap_encryption']);
 
-    mysqli_query($mysqli,"UPDATE settings SET config_smtp_host = '$config_smtp_host', config_smtp_port = $config_smtp_port, config_smtp_encryption = '$config_smtp_encryption', config_smtp_username = '$config_smtp_username', config_smtp_password = '$config_smtp_password', config_mail_from_email = '$config_mail_from_email', config_mail_from_name = '$config_mail_from_name', config_imap_host = '$config_imap_host', config_imap_port = $config_imap_port, config_imap_encryption = '$config_imap_encryption' WHERE company_id = 1");
+    mysqli_query($mysqli,"UPDATE settings SET config_smtp_host = '$config_smtp_host', config_smtp_port = $config_smtp_port, config_smtp_encryption = '$config_smtp_encryption', config_smtp_username = '$config_smtp_username', config_smtp_password = '$config_smtp_password', config_mail_from_email = '$config_mail_from_email', config_mail_from_name = '$config_mail_from_name', config_imap_host = '$config_imap_host', config_imap_port = $config_imap_port, config_imap_encryption = '$config_imap_encryption', config_imap_username = '$config_imap_username', config_imap_password = '$config_imap_password' WHERE company_id = 1");
 
 
     //Update From Email and From Name if Invoice/Quote or Ticket fields are blank
@@ -133,7 +135,7 @@ if (isset($_POST['test_email_imap'])) {
     $imap_mailbox = "$config_imap_host:$config_imap_port/imap/readonly/$config_imap_encryption";
 
     // Connect
-    $imap = imap_open("{{$imap_mailbox}}INBOX", $config_smtp_username, $config_smtp_password);
+    $imap = imap_open("{{$imap_mailbox}}INBOX", $config_imap_username, $config_imap_password);
 
     if ($imap) {
         $_SESSION['alert_message'] = "Connected successfully";

--- a/settings_mail.php
+++ b/settings_mail.php
@@ -121,6 +121,31 @@ require_once("inc_all_settings.php"); ?>
                     </div>
                 </div>
 
+                <div class='form-group'>
+                    <label>IMAP Username</label>
+                    <div class='input-group'>
+                        <div class='input-group-prepend'>
+                            <span class='input-group-text'><i class='fa fa-fw fa-user'></i></span>
+                        </div>
+                        <input type='text' class='form-control' name='config_imap_username' placeholder='Username' value="<?php
+                        echo nullable_htmlentities($config_imap_username); ?>" required>
+                    </div>
+                </div>
+
+                <div class='form-group'>
+                    <label>IMAP Password</label>
+                    <div class='input-group'>
+                        <div class='input-group-prepend'>
+                            <span class='input-group-text'><i class='fa fa-fw fa-key'></i></span>
+                        </div>
+                        <input type='password' class='form-control' data-toggle='password' name='config_imap_password' placeholder='Password' value="<?php
+                        echo nullable_htmlentities($config_imap_password); ?>" autocomplete='new-password' required>
+                        <div class='input-group-append'>
+                            <span class='input-group-text'><i class='fa fa-fw fa-eye'></i></span>
+                        </div>
+                    </div>
+                </div>
+
                 <hr>
 
                 <button type="submit" name="edit_mail_settings" class="btn btn-primary text-bold"><i class="fas fa-check mr-2"></i>Save</button>


### PR DESCRIPTION
I had a use case requiring separate credentials for IMAP - created a simple update to add credentials support.

Decided to keep it simple rather than add extra logic for cross-credential checking. If both sets of credentials are the same, they can just be duplicated.

DB version bumped to 0.6.2.