### PR TITLE
Google Charts - Use HTTPS instead

### DIFF
--- a/rfc6238.php
+++ b/rfc6238.php
@@ -59,7 +59,7 @@ class TokenAuth6238 {
     }
 
     public static function getBarCodeUrl($username, $domain, $secretkey, $issuer) {
-        $url = "http://chart.apis.google.com/chart";
+        $url = "https://chart.apis.google.com/chart";
         $url = $url."?chs=200x200&chld=M|0&cht=qr&chl=otpauth://totp/";
         $url = $url.$username . "@" . $domain . "%3Fsecret%3D" . $secretkey . '%26issuer%3D' . rawurlencode($issuer);
 


### PR DESCRIPTION
https://sonarcloud.io/project/security_hotspots?id=itflow-org_itflow&hotspots=AX_R-9KMzwNqFnrnOWyE