### PR TITLE
Fix client delete function

### DIFF
--- a/client_delete_modal.php
+++ b/client_delete_modal.php
@@ -5,7 +5,7 @@
                 <div class="mb-4" style="text-align: center;">
                     <i class="far fa-10x fa-times-circle text-danger mb-3 mt-3"></i>
                     <h2>Are you really, really, really sure?</h2>
-                    <h6 class="mb-4 text-secondary">Do you really want to <b>delete <?php echo $client_name; ?> and ALL associated data</b>. This includes <?php echo $client_name; ?>'s documents, tickets, files, financial data, logs, etc. <br><br>This process cannot be undone.</h6>
+                    <h6 class="mb-4 text-secondary">Do you really want to <b>delete <?php echo $client_name; ?> and ALL associated data</b>? This includes <?php echo $client_name; ?>'s documents, tickets, files, financial data, logs, etc. <br><br>This process cannot be undone.</h6>
                     <div class="form-group">
                         <input type="hidden" id="clientName<?php echo $client_id ?>" value="<?php echo $client_name; ?>">
                         <input class="form-control" type="text" id="clientNameProvided<?php echo $client_id ?>" onkeyup="validateClientNameDelete(<?php echo $client_id ?>)" placeholder="Type '<?php echo $client_name; ?>' to confirm data deletion">

--- a/client_delete_modal.php
+++ b/client_delete_modal.php
@@ -1,0 +1,20 @@
+<div class="modal" id="deleteClientModal<?php echo $client_id; ?>" tabindex="-1">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-body">
+                <div class="mb-4" style="text-align: center;">
+                    <i class="far fa-10x fa-times-circle text-danger mb-3 mt-3"></i>
+                    <h2>Are you really, really, really sure?</h2>
+                    <h6 class="mb-4 text-secondary">Do you really want to <b>delete <?php echo $client_name; ?> and ALL associated data</b>. This includes <?php echo $client_name; ?>'s documents, tickets, files, financial data, logs, etc. <br><br>This process cannot be undone.</h6>
+                    <div class="form-group">
+                        <input type="hidden" id="clientName<?php echo $client_id ?>" value="<?php echo $client_name; ?>">
+                        <input class="form-control" type="text" id="clientNameProvided<?php echo $client_id ?>" onkeyup="validateClientNameDelete(<?php echo $client_id ?>)" placeholder="Type '<?php echo $client_name; ?>' to confirm data deletion">
+                    </div>
+                    <button type="button" class="btn btn-outline-secondary btn-lg px-5 mr-4" data-dismiss="modal">Cancel</button>
+                    <a class="btn btn-danger btn-lg px-5 disabled" id="clientDeleteButton<?php echo $client_id ?>" href="post.php?delete_client=<?php echo $client_id; ?>&csrf_token=<?php echo $_SESSION['csrf_token'] ?>">Yes, Delete!</a>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+<script src="js/client_delete_confirm.js"></script>

--- a/inc_client_top_head.php
+++ b/inc_client_top_head.php
@@ -24,7 +24,7 @@
                         </a>
                         <?php if ($session_user_role == 3) { ?>
                         <div class="dropdown-divider"></div>
-                        <a class="dropdown-item text-danger text-bold confirm-link" href="#" data-toggle="modal" data-target="#deleteClientModal<?php echo $client_id; ?>">
+                        <a class="dropdown-item text-danger text-bold" href="#" data-toggle="modal" data-target="#deleteClientModal<?php echo $client_id; ?>">
                             <i class="fas fa-fw fa-trash mr-2"></i>Delete Client
                         </a>
                         <?php } ?>
@@ -33,11 +33,11 @@
                 <?php } ?>
             </div>
         </div>
-        
+
         <div class="collapse show" id="clientHeader">
 
             <div class="row">
-                
+
                 <div class="col-md border-top">
                     <h5 class="text-secondary mt-1">Primary Location</h5>
                     <?php if (!empty($location_address)) { ?>
@@ -131,7 +131,7 @@
                 </div>
                 <?php } ?>
 
-                
+
                 <div class="col-md border-left border-top">
                     <h5 class="text-secondary mt-1">Support</h5>
                     <div class="ml-1 text-secondary">Open Tickets
@@ -146,7 +146,7 @@
                     <?php echo $client_tags_display; ?>
                     <?php } ?>
                 </div>
-                
+
             </div>
         </div>
     </div>
@@ -155,6 +155,7 @@
 <?php
 
 require_once("client_edit_modal.php");
+require_once("client_delete_modal.php");
 require_once("client_download_pdf_modal.php");
 require_once("category_quick_add_modal.php");
 

--- a/post/client.php
+++ b/post/client.php
@@ -176,12 +176,10 @@ if (isset($_GET['undo_archive_client'])) {
 
 if (isset($_GET['delete_client'])) {
 
-    // Removing this function from the frontend as this is extremely destructive. Its best to use Archive, use this for development or test purposes only.
-
     validateAdminRole();
 
     // CSRF Check
-    // validateCSRFToken($_GET['csrf_token']);
+    validateCSRFToken($_GET['csrf_token']);
 
     $client_id = intval($_GET['delete_client']);
 


### PR DESCRIPTION
Bugfix + Enhancement

When testing the recent changes, I noticed the restored client delete modal wasn't properly directing people to the `post.php?delete_client` page - it would just hang after you click Yes.

Whilst working on fixing this using the new confirmation modals, I figured that deleting an **entire clients data** shouldn't be as easy as clicking "Yes", so restored the old confirmation dialog where you're required to enter the client name (complete with CSRF). 
Hope you agree that this is the best way forward for this specific extremely destructive function! :)

![image](https://github.com/itflow-org/itflow/assets/32306651/9e1d9215-d2c9-4c85-9cb0-3a297fb7405c)

![image](https://github.com/itflow-org/itflow/assets/32306651/3ee5661c-dd77-4708-8c07-ea967e4e4884)
