### PR TITLE
Users - Prevent modifying yourself via users.php, should use profile

### DIFF
--- a/users.php
+++ b/users.php
@@ -143,6 +143,7 @@ $num_rows = mysqli_fetch_row(mysqli_query($mysqli, "SELECT FOUND_ROWS()"));
                         <td class="text-center"><?php echo $mfa_status_display; ?></td>
                         <td><?php echo $last_login; ?></td>
                         <td>
+                            <?php if ($user_id !== $session_user_id) {   // Prevent modifying self ?>
                             <div class="dropdown dropleft text-center">
                                 <button class="btn btn-secondary btn-sm" type="button" data-toggle="dropdown">
                                     <i class="fas fa-ellipsis-h"></i>
@@ -166,6 +167,7 @@ $num_rows = mysqli_fetch_row(mysqli_query($mysqli, "SELECT FOUND_ROWS()"));
                                     </a>
                                 </div>
                             </div>
+                            <?php } ?>
                         </td>
                     </tr>
 


### PR DESCRIPTION
This PR prevents users from accidentally disabling/archiving themselves via the admin settings page.

Self name/email/password changes should be done via profile settings.