### PR TITLE
Client logins/passwords - Add basic password rotation report

### DIFF
--- a/report_password_rotation.php
+++ b/report_password_rotation.php
@@ -1,0 +1,73 @@
+<?php
+
+require_once("inc_all_reports.php");
+validateTechRole();
+
+// TODO: Default to 90 but allow input field to change this
+if (isset($_GET['days'])) {
+    $days = intval($_GET['days']);
+} else {
+    $days = 90;
+}
+
+$passwords_not_rotated_sql = mysqli_query($mysqli,
+    "SELECT login_id, login_name, login_description, login_password_changed_at, login_client_id, client_id, client_name
+        FROM logins
+        LEFT JOIN clients ON login_client_id = client_id
+        WHERE DATE(login_password_changed_at) < DATE_SUB(CURDATE(), INTERVAL $days DAY)
+        ORDER BY client_name"
+);
+
+?>
+
+    <div class="card card-dark">
+        <div class="card-header py-2">
+            <h3 class="card-title mt-2"><i class="fas fa-fw fa-life-ring mr-2"></i>Login entry passwords not changed/rotated in the last 90 days</h3>
+            <div class="card-tools">
+                <button type="button" class="btn btn-primary d-print-none" onclick="window.print();"><i class="fas fa-fw fa-print mr-2"></i>Print</button>
+            </div>
+        </div>
+        <div class="card-body">
+
+            <div class="table-responsive-sm">
+                <table class="table table-striped">
+                    <thead>
+                    <tr>
+                        <th>Client</th>
+                        <th class="text-right">Login Name</th>
+                        <th class="text-right">Login Description</th>
+                        <th class="text-right">Login Password Last Changed</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+
+                    <?php
+
+                    while ($row = mysqli_fetch_array($passwords_not_rotated_sql)) {
+
+                        $login_id = intval($row['login_id']);
+                        $login_name = nullable_htmlentities($row['login_name']);
+                        $login_description = nullable_htmlentities($row['login_description']);
+                        $login_password_changed = nullable_htmlentities($row['login_password_changed_at']);
+                        $client_id = intval($row['client_id']);
+                        $client_name = nullable_htmlentities($row['client_name']);
+
+                        ?>
+
+                        <tr>
+                            <td><?php echo $client_name; ?></td>
+                            <td class="text-right"><?php echo $login_name; ?></td>
+                            <td class="text-right"><?php echo $login_description; ?></td>
+                            <td class="text-right"><?php echo timeAgo($login_password_changed) . " (" . $login_password_changed . ")" ?></td>
+                        </tr>
+
+                    <?php } ?>
+
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+
+<?php
+require_once("footer.php");

--- a/reports_side_nav.php
+++ b/reports_side_nav.php
@@ -1,7 +1,7 @@
 <!-- Main Sidebar Container -->
 <aside class="main-sidebar sidebar-dark-primary d-print-none">
 
-    <a class="brand-link pb-1 mt-1" href="clients.php">    
+    <a class="brand-link pb-1 mt-1" href="clients.php">
         <p class="h5"><i class="nav-icon fas fa-arrow-left ml-3 mr-2"></i> Back | <strong>Reports</strong></p>
     </a>
 
@@ -86,6 +86,12 @@
                             <p>Tickets by Client</p>
                         </a>
                     </li>
+                    <li class="nav-item">
+                        <a href="report_password_rotation.php" class="nav-link <?php if (basename($_SERVER["PHP_SELF"]) == "report_password_rotation.php") { echo "active"; } ?>">
+                            <i class="nav-icon fas fa-life-ring"></i>
+                            <p>Password rotation</p>
+                        </a>
+                    </li>
 
                 <?php } // End technical reports IF statement ?>
 
@@ -95,9 +101,9 @@
         <!-- /.sidebar-menu -->
 
         <div class="sidebar-custom mb-3">
-            
+
         </div>
-        
+
     </div>
     <!-- /.sidebar -->
 </aside>


### PR DESCRIPTION
This basic report shows you which client login entries have not had their passwords changed/rotated in the last 90 days. 

Password rotation is no longer encouraged for users memorising their _own_ passwords. However, password rotation is essential for service/shared accounts commonly used by MSPs in situations where individual accounts aren't available/viable.