### PR TITLE
Email parsing for all domains registered under a client

### DIFF
--- a/client_domains.php
+++ b/client_domains.php
@@ -72,6 +72,7 @@ $num_rows = mysqli_fetch_row(mysqli_query($mysqli, "SELECT FOUND_ROWS()"));
                         $domain_webhost = intval($row['domain_webhost']);
                         $domain_expire = nullable_htmlentities($row['domain_expire']);
                         $domain_registrar_name = nullable_htmlentities($row['vendor_name']);
+                        $domain_created_at = nullable_htmlentities($row['domain_created_at']);
                         if (empty($domain_registrar_name)) {
                             $domain_registrar_name = "-";
                         }
@@ -82,7 +83,6 @@ $num_rows = mysqli_fetch_row(mysqli_query($mysqli, "SELECT FOUND_ROWS()"));
                         if ($row) {
                             $domain_webhost_name = nullable_htmlentities($row['vendor_name']);
                         }
-                        $domain_created_at = nullable_htmlentities($row['domain_created_at']);
 
                         ?>
                         <tr>

--- a/functions.php
+++ b/functions.php
@@ -516,7 +516,7 @@ function sendSingleEmail($config_smtp_host, $config_smtp_username, $config_smtp_
         $smtp_auth = true;
     }
 
-    try{
+    try {
         // Mail Server Settings
         $mail->CharSet = "UTF-8";                                   // Specify UTF-8 charset to ensure symbols ($/£) load correctly
         $mail->SMTPDebug = 0;                                       // No Debugging
@@ -712,13 +712,13 @@ function shortenClient($client) {
 
     // Break into words.
     $words = explode(' ', trim($cleaned));
-    
+
     $shortened = '';
 
     // If there's only one word.
     if (count($words) == 1) {
         $word = $words[0];
-        
+
         if (strlen($word) <= 3) {
             return strtoupper($word);
         }
@@ -753,22 +753,22 @@ function roundToNearest15($time) {
 
     // Extract hours, minutes, and seconds from the matched time string
     list(, $hours, $minutes, $seconds) = $matches;
-    
+
     // Convert everything to seconds for easier calculation
     $totalSeconds = ($hours * 3600) + ($minutes * 60) + $seconds;
-    
+
     // Calculate the remainder when divided by 900 seconds (15 minutes)
     $remainder = $totalSeconds % 900;
-    
+
     if ($remainder > 450) {  // If remainder is more than 7.5 minutes (450 seconds), round up
         $totalSeconds += (900 - $remainder);
     } else {  // Else round down
         $totalSeconds -= $remainder;
     }
-    
+
     // Convert total seconds to decimal hours
     $decimalHours = $totalSeconds / 3600;
-    
+
     // Return the decimal hours
     return number_format($decimalHours, 2);
 }

--- a/ticket.php
+++ b/ticket.php
@@ -327,15 +327,15 @@ if (isset($_GET['ticket_id'])) {
                             </div>
 
                             <?php if(!empty($contact_email)){ ?>
-                            
-                            <div class="col-md-2">
-                                <div class="form-group">
-                                    <div class="custom-control custom-checkbox">
-                                        <input type="checkbox" class="custom-control-input" id="ticket_reply_type_checkbox" name="public_reply_type" value="1" checked>
-                                        <label class="custom-control-label" for="ticket_reply_type_checkbox">Email contact<br><small class="text-secondary">(Public Update)</small></label>
+
+                                <div class="col-md-2">
+                                    <div class="form-group">
+                                        <div class="custom-control custom-checkbox">
+                                            <input type="checkbox" class="custom-control-input" id="ticket_reply_type_checkbox" name="public_reply_type" value="1" checked>
+                                            <label class="custom-control-label" for="ticket_reply_type_checkbox">Email contact<br><small class="text-secondary">(Public Update)</small></label>
+                                        </div>
                                     </div>
                                 </div>
-                            </div>
 
                             <?php } ?>
 
@@ -483,13 +483,13 @@ if (isset($_GET['ticket_id'])) {
                 <!-- Contact card -->
                 <div class="card card-body card-outline card-dark mb-3">
                     <h4 class="text-secondary">Contact</h4>
-                    
+
                     <?php if (!empty($contact_id)) { ?>
 
                         <div>
-    						<i class="fa fa-fw fa-user text-secondary ml-1 mr-2"></i><a href="#" data-toggle="modal" data-target="#editTicketContactModal<?php echo $ticket_id; ?>"><strong><?php echo $contact_name; ?></strong>
+                            <i class="fa fa-fw fa-user text-secondary ml-1 mr-2"></i><a href="#" data-toggle="modal" data-target="#editTicketContactModal<?php echo $ticket_id; ?>"><strong><?php echo $contact_name; ?></strong>
                             </a>
-    					</div>
+                        </div>
 
                         <?php
 
@@ -517,32 +517,36 @@ if (isset($_GET['ticket_id'])) {
                             </div>
                         <?php } ?>
 
-                        <hr>
-
                         <?php
 
+                        // Previous tickets
+                        $prev_ticket_id = $prev_ticket_subject = $prev_ticket_status = ''; // Default blank
+
                         $sql_prev_ticket = "SELECT ticket_id, ticket_created_at, ticket_subject, ticket_status, ticket_assigned_to FROM tickets WHERE ticket_contact_id = $contact_id AND ticket_id  <> $ticket_id ORDER BY ticket_id DESC LIMIT 1";
-                        $row = mysqli_fetch_assoc(mysqli_query($mysqli, $sql_prev_ticket));
+                        $prev_ticket_row = mysqli_fetch_assoc(mysqli_query($mysqli, $sql_prev_ticket));
 
-                        $prev_ticket_id = intval($row['ticket_id']);
-                        $prev_ticket_subject = nullable_htmlentities($row['ticket_subject']);
-                        $prev_ticket_status = nullable_htmlentities($row['ticket_status']);
-                        ?>
+                        if ($prev_ticket_row) {
+                            $prev_ticket_id = intval($prev_ticket_row['ticket_id']);
+                            $prev_ticket_subject = nullable_htmlentities($prev_ticket_row['ticket_subject']);
+                            $prev_ticket_status = nullable_htmlentities($prev_ticket_row['ticket_status']);
+                            ?>
 
-                        <div>
-                            <i class="fa fa-fw fa-history text-secondary ml-1 mr-2"></i><b>Previous ticket:</b>
-                            <a href="ticket.php?ticket_id=<?php echo $prev_ticket_id; ?>"><?php echo $prev_ticket_subject; ?></a>
-                        </div>
-                        <div class="mt-1">
-                            <?php if ($prev_ticket_status == 'Open') { ?>
+                            <hr>
+                            <div>
+                                <i class="fa fa-fw fa-history text-secondary ml-1 mr-2"></i><b>Previous ticket:</b>
+                                <a href="ticket.php?ticket_id=<?php echo $prev_ticket_id; ?>"><?php echo $prev_ticket_subject; ?></a>
+                            </div>
+                            <div class="mt-1">
                                 <i class="fa fa-fw fa-hourglass-start text-secondary ml-1 mr-2"></i><strong>Status:</strong>
-                                <span class="text-danger"><?php echo $prev_ticket_status; ?></span>
-                            <?php } else { ?>
-                                <i class="fa fa-fw fa-hourglass-start text-secondary ml-1 mr-2"></i><strong>Status:</strong>
-                                <span class="text-success"><?php echo $prev_ticket_status; ?></span>
-                            <?php } ?>
-                        </div>
-                        
+                                <?php if ($prev_ticket_status == 'Open') { ?>
+                                    <span class="text-danger"><?php echo $prev_ticket_status; ?></span>
+                                <?php } else { ?>
+                                    <span class="text-success"><?php echo $prev_ticket_status; ?></span>
+                                <?php } ?>
+                            </div>
+
+                        <?php } ?> <!-- End previous ticket IF statement -->
+
                     <?php } else { ?>
                         <div>
                             <a href="#" data-toggle="modal" data-target="#editTicketContactModal<?php echo $ticket_id; ?>"><i class="fa fa-fw fa-plus mr-2"></i>Add a Contact</a>
@@ -565,12 +569,12 @@ if (isset($_GET['ticket_id'])) {
                     $sql_ticket_watchers = mysqli_query($mysqli, "SELECT * FROM ticket_watchers WHERE watcher_ticket_id = $ticket_id ORDER BY watcher_email DESC");
                     while ($ticket_watcher_row = mysqli_fetch_array($sql_ticket_watchers)) {
                         $ticket_watcher_email = nullable_htmlentities($ticket_watcher_row['watcher_email']);
-                    ?>
+                        ?>
                         <div class='mt-1'>
                             <i class="fa fa-fw fa-eye text-secondary ml-1 mr-2"></i><?php echo $ticket_watcher_email; ?>
                         </div>
                     <?php } ?>
-                
+
                 </div>
                 <!-- End Ticket watchers card -->
 
@@ -586,14 +590,14 @@ if (isset($_GET['ticket_id'])) {
                     <div class="mt-2">
                         <i class="fa fa-fw fa-history text-secondary ml-1 mr-2"></i>Updated: <strong><?php echo $ticket_updated_at; ?></strong>
                     </div>
-                    
+
                     <?php
                     if ($ticket_status == "Closed") {
                         $sql_closed_by = mysqli_query($mysqli, "SELECT * FROM tickets, users WHERE ticket_closed_by = user_id");
                         $row = mysqli_fetch_array($sql_closed_by);
-                        $ticket_closed_by_display = nullable_htmlentities($row['user_name']); 
-                    ?>
-                        
+                        $ticket_closed_by_display = nullable_htmlentities($row['user_name']);
+                        ?>
+
                         <div class="mt-1">
                             <i class="fa fa-fw fa-user text-secondary ml-1 mr-2"></i>Closed by: <?php echo ucwords($ticket_closed_by_display); ?>
                         </div>
@@ -601,7 +605,7 @@ if (isset($_GET['ticket_id'])) {
                             <i class="fa fa-fw fa-comment-dots text-secondary ml-1 mr-2"></i>Feedback: <?php echo $ticket_feedback; ?>
                         </div>
                     <?php } ?>
-                    
+
                     <?php if (!empty($ticket_total_reply_time)) { ?>
                         <div class="mt-1">
                             <i class="far fa-fw fa-clock text-secondary ml-1 mr-2"></i>Total time worked: <?php echo $ticket_total_reply_time; ?>
@@ -613,13 +617,13 @@ if (isset($_GET['ticket_id'])) {
                 <!-- Asset card -->
                 <div class="card card-body card-outline card-dark mb-3">
                     <h4 class="text-secondary">Asset</h4>
-                    
+
                     <?php if ($asset_id == 0) { ?>
-                    
+
                         <div>
                             <a href="#" data-toggle="modal" data-target="#editTicketAssetModal<?php echo $ticket_id; ?>"><i class="fa fa-fw fa-plus mr-2"></i>Add an Asset</a>
                         </div>
-                    
+
                     <?php } else { ?>
 
                         <div>
@@ -686,7 +690,7 @@ if (isset($_GET['ticket_id'])) {
                                                     <i class="fas fa-fw fa-ticket-alt"></i>
                                                     Ticket: <a href="ticket.php?ticket_id=<?php echo $service_ticket_id; ?>"><?php echo "$service_ticket_prefix$service_ticket_number" ?></a> <?php echo "on $service_ticket_created_at - <b>$service_ticket_subject</b> ($service_ticket_status)"; ?>
                                                 </p>
-                                            <?php
+                                                <?php
                                             }
                                             ?>
                                         </div>
@@ -699,13 +703,13 @@ if (isset($_GET['ticket_id'])) {
                             </div>
 
                         <?php } // End Ticket asset Count ?>
-                   
+
                     <?php } // End if asset_id == 0 else ?>
 
                 </div>
                 <!-- End Asset card -->
 
-                <!-- Vendor card --> 
+                <!-- Vendor card -->
                 <div class="card card-body card-outline card-dark mb-3">
                     <h4 class="text-secondary">Vendor</h4>
                     <?php if (empty($vendor_id)) { ?>
@@ -784,14 +788,14 @@ if (isset($_GET['ticket_id'])) {
                             <i class="fas fa-fw fa-file-invoice mr-2"></i>Invoice Ticket
                         </a>
                     <?php }
-        
+
                     if ($ticket_status !== "Closed") { ?>
                         <a href="post.php?close_ticket=<?php echo $ticket_id; ?>" class="btn btn-secondary btn-block confirm-link">
                             <i class="fas fa-fw fa-gavel mr-2"></i>Close Ticket
                         </a>
                     <?php } ?>
                 </div>
-    
+
             </div>
 
         </div>


### PR DESCRIPTION
- **Add support for email parsing/contact creation for all domains registered under a client in the domains module, rather than just the client main website.**

- Additionally fix domain_created_at bug and move the new ticket auto-reply message to the email queue instead

_Future work: Make ticket parsing work with HTML emails (HTML emails break agent notifs)_