### PR TITLE
Contact small edits

### DIFF
--- a/client_contact_edit_modal.php
+++ b/client_contact_edit_modal.php
@@ -13,6 +13,7 @@
                 <input type="hidden" name="contact_important" value="0">
                 <input type="hidden" name="contact_billing" value="0">
                 <input type="hidden" name="contact_technical" value="0">
+                <input type="hidden" name="send_email" value="0">
                 <!-- End prevent undefined errors -->
                 <input type="hidden" name="contact_id" value="<?php echo $contact_id; ?>">
                 <input type="hidden" name="client_id" value="<?php echo $client_id; ?>">
@@ -198,7 +199,7 @@
                                         <div class="input-group-prepend">
                                             <span class="input-group-text"><i class="fa fa-fw fa-key"></i></span>
                                         </div>
-                                        <input type="password" class="form-control" data-toggle="password" name="contact_password" placeholder="Leave blank for no change" autocomplete="new-password">
+                                        <input type="password" class="form-control" data-toggle="password" name="contact_password" placeholder="Leave blank for no change" autocomplete="new-password" minlength="8">
                                         <div class="input-group-append">
                                             <span class="input-group-text"><i class="fa fa-fw fa-eye"></i></span>
                                         </div>
@@ -207,7 +208,7 @@
                             </div>
 
                             <div class="form-check">
-                                <input type="checkbox" class="form-check-input" name="send_email" value=""/>
+                                <input type="checkbox" class="form-check-input" name="send_email" value="1"/>
                                 <label class="form-check-label">Send user e-mail with login details?</label>
                             </div>
 

--- a/client_contacts.php
+++ b/client_contacts.php
@@ -210,7 +210,7 @@ $num_rows = mysqli_fetch_row(mysqli_query($mysqli, "SELECT FOUND_ROWS()"));
                                         </a>
                                         <?php if ($session_user_role == 3 && $contact_primary == 0) { ?>
                                             <div class="dropdown-divider"></div>
-                                            <a class="dropdown-item text-danger" href="post.php?anonymize_contact=<?php echo $contact_id; ?>">
+                                            <a class="dropdown-item text-danger confirm-link" href="post.php?anonymize_contact=<?php echo $contact_id; ?>">
                                                 <i class="fas fa-fw fa-user-secret mr-2"></i>Anonymize & Archive
                                             </a>
                                             <div class="dropdown-divider"></div>

--- a/portal/check_login.php
+++ b/portal/check_login.php
@@ -50,6 +50,7 @@ $session_contact_initials = initials($session_contact_name);
 $session_contact_title = sanitizeInput($contact['contact_title']);
 $session_contact_email = sanitizeInput($contact['contact_email']);
 $session_contact_photo = sanitizeInput($contact['contact_photo']);
+$session_contact_pin = sanitizeInput($contact['contact_pin']);
 $session_contact_primary = intval($contact['contact_primary']);
 
 $session_contact_is_technical_contact = false;

--- a/portal/profile.php
+++ b/portal/profile.php
@@ -13,6 +13,7 @@ require_once('inc_portal.php');
 
     <p>Name: <?php echo $session_contact_name ?></p>
     <p>Email: <?php echo $session_contact_email ?></p>
+    <p>PIN: <?php echo $session_contact_pin ?></p>
     <p>Client: <?php echo $session_client_name ?></p>
     <br>
     <p>Client Primary Contact: <?php if ($session_contact_primary == 1) {echo "Yes"; } else {echo "No";} ?></p>
@@ -35,7 +36,7 @@ require_once('inc_portal.php');
                     <div class="input-group-prepend">
                         <span class="input-group-text"><i class="fa fa-fw fa-lock"></i></span>
                     </div>
-                    <input type="password" class="form-control" minlength="6" required data-toggle="password" name="new_password" placeholder="Leave blank for no change" autocomplete="new-password">
+                    <input type="password" class="form-control" minlength="8" required data-toggle="password" name="new_password" placeholder="Leave blank for no change" autocomplete="new-password">
                 </div>
             </div>
             <button type="submit" name="edit_profile" class="btn btn-primary text-bold mt-3"><i class="fas fa-check mr-2"></i>Save password</button>


### PR DESCRIPTION
- Adjust behaviour when selecting "Send user e-mail with login details?" (show reset link OR prompt user to change password if tech set one)
- Email wording change (remove ITFlow reference and replace with MSP name)
- Show contact PIN in the portal
- Add confirm dialogue to anonymise and archive
- Bump password min length to 8 (and enforce on tech side)
- Bugfix undefined send_email value