### PR TITLE
Add function to reset all user/agent passwords in case of IR

### DIFF
--- a/user_all_reset_password_modal.php
+++ b/user_all_reset_password_modal.php
@@ -1,0 +1,31 @@
+<div class="modal" id="resetAllUserPassModal" tabindex="-1">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <div class="modal-body">
+                <div class="mb-4" style="text-align: center;">
+                    <i class="far fas fa-10x fa-skull-crossbones text-danger mb-3 mt-3"></i>
+                    <h2>Incident Response: Agent Password Reset</h2>
+                    <br>
+                    <div class="alert alert-danger" role="alert">
+                        <b>This is a potentially destructive function.<br>It is intended to be used as part of a potential security incident.</b>
+                    </div>
+                    <h6 class="mb-4 text-secondary"><b>All ITFlow agent passwords will be reset and shown to you </b><i>(except yours - change yours first!)</i>.<br/><br/>You should communicate temporary passwords to agents out of band (e.g. via a phone call) and require they are changed ASAP.</h6>
+                    <form action="post.php" method="POST">
+                        <input type="hidden" name="csrf_token" value="<?php echo $_SESSION['csrf_token'] ?>">
+                        <div class="row col-7 offset-4">
+                            <div class="input-group">
+                                <div class="input-group-prepend">
+                                    <input type="password" class="form-control" placeholder="Enter your account password to continue" name="admin_password" autocomplete="new-password" required>
+                                </div>
+                            </div>
+                        </div>
+                        <br>
+                        <button class="btn btn-danger" type="submit" name="ir_reset_user_password"><i class="fas fa-fw fa-key mr-2"></i>Reset passwords</button>
+                    </form>
+                </div>
+                <button type="button" class="btn btn-outline-secondary btn-lg px-5 mr-4" data-dismiss="modal">Cancel</button>
+
+            </div>
+        </div>
+    </div>
+</div>

--- a/users.php
+++ b/users.php
@@ -33,6 +33,10 @@ $num_rows = mysqli_fetch_row(mysqli_query($mysqli, "SELECT FOUND_ROWS()"));
                 <button type="button" class="btn btn-primary dropdown-toggle dropdown-toggle-split" data-toggle="dropdown"></button>
                 <div class="dropdown-menu">
                     <!--<a class="dropdown-item text-dark" href="#" data-toggle="modal" data-target="#userInviteModal"><i class="fas fa-paper-plane mr-2"></i>Invite User</a>-->
+                    <?php if ($num_rows[0] > 1) { ?>
+                        <div class="dropdown-divider"></div>
+                        <a class="dropdown-item text-danger" href="#" data-toggle="modal" data-target="#resetAllUserPassModal"><i class="fas fa-skull-crossbones mr-2"></i>IR</a>
+                    <?php } ?>
                 </div>
             </div>
         </div>
@@ -197,4 +201,5 @@ $num_rows = mysqli_fetch_row(mysqli_query($mysqli, "SELECT FOUND_ROWS()"));
 require_once("user_add_modal.php");
 require_once("user_invite_modal.php");
 require_once("user_export_modal.php");
+require_once("user_all_reset_password_modal.php");
 require_once("footer.php");


### PR DESCRIPTION
In the case of a potential security incident, this PR adds the ability to force all agent passwords are changed and distributed manually by the system administrator. 

![image](https://github.com/itflow-org/itflow/assets/32306651/46e215f2-f164-4fdf-8235-ea3824dd0bb1)

_You must have more than 1 ITFlow user for the option to show on Settings > Users. The modal could still use some CSS love for the password box_