### PR TITLE
Add background ajax query in an attempt to prevent session timeout

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -24,6 +24,7 @@
 <script src="plugins/tinymce/tinymce.min.js" referrerpolicy="origin"></script>
 <script src="plugins/Show-Hide-Passwords-Bootstrap-4/bootstrap-show-password.min.js"></script>
 <script src="plugins/clipboardjs/clipboard.min.js"></script>
+<script src="js/keepalive.js"></script>
 
 <!-- AdminLTE App -->
 <script src="dist/js/adminlte.min.js"></script>

--- a/js/keepalive.js
+++ b/js/keepalive.js
@@ -1,0 +1,18 @@
+// Keep PHP sessions alive
+// Sends requests to keepalive.php in the background every 10 mins to prevent PHP garbage collection ending sessions
+
+function keep_alive() {
+
+    //Send a GET request to keepalive.php as keepalive.php?keepalive
+    jQuery.get(
+        "keepalive.php",
+        {keepalive: 'true'},
+        function(data) {
+            // Don't care about a response
+        }
+    );
+
+}
+
+// Run every 10 mins
+setInterval(keep_alive, 600000);

--- a/keepalive.php
+++ b/keepalive.php
@@ -1,0 +1,8 @@
+<?php
+
+// Keep PHP sessions alive
+// Receives requests via AJAX in the background every 10 mins to prevent PHP garbage collection ending sessions
+//  See footer.php & js/keepalive.js
+
+session_start();
+session_write_close();


### PR DESCRIPTION
Whilst this isn't something I've run into myself, we've had a few posts on the forum about sessions timing out when working on things like editing documents.

This PR adds a AJAX background query to keepalive.php every 10 mins which _should_ keep sessions alive.