### PR TITLE
Expand range of allowed file extensions for email to ticket attachments

### DIFF
--- a/cron_ticket_email_parser.php
+++ b/cron_ticket_email_parser.php
@@ -90,7 +90,8 @@ require_once "plugins/php-mime-mail-parser/src/Parser.php";
 
 
 // Allowed attachment extensions
-$allowed_extensions = array('jpg', 'jpeg', 'gif', 'png', 'webp', 'pdf', 'txt', 'md', 'doc', 'docx', 'csv', 'xls', 'xlsx', 'xlsm', 'zip', 'tar', 'gz');
+$allowed_extensions = array('jpg', 'jpeg', 'gif', 'png', 'webp', 'pdf', 'txt', 'md', 'doc', 'docx', 'odt', 'csv', 'xls', 'xlsx', 'ods', 'pptx', 'odp', 'zip', 'tar', 'gz', 'xml', 'msg', 'json', 'wav', 'mp3', 'ogg', 'mov', 'mp4', 'av1', 'ovpn');
+
 
 // Function to raise a new ticket for a given contact and email them confirmation (if configured)
 function addTicket($contact_id, $contact_name, $contact_email, $client_id, $date, $subject, $message, $attachments) {


### PR DESCRIPTION
These match those suggested in the client_file_upload_modal