### PR TITLE
Add ability to edit contact on a scheduled ticket

### DIFF
--- a/ajax.php
+++ b/ajax.php
@@ -329,6 +329,16 @@ if (isset($_GET['scheduled_ticket_get_json_details'])) {
     $client_id = intval($_GET['client_id']);
     $ticket_id = intval($_GET['ticket_id']);
 
+    $contact_sql = mysqli_query($mysqli, "SELECT contact_id, contact_name FROM contacts 
+    WHERE contact_client_id = $client_id 
+    AND contact_archived_at IS NULL
+    ORDER BY contact_primary DESC, contact_technical DESC, contact_name ASC"
+    );
+    while ($row = mysqli_fetch_array($contact_sql)) {
+        $response['contacts'][] = $row;
+    }
+
+
     $ticket_sql = mysqli_query($mysqli, "SELECT * FROM scheduled_tickets
     WHERE scheduled_ticket_id = $ticket_id
     AND scheduled_ticket_client_id = $client_id LIMIT 1");

--- a/ajax.php
+++ b/ajax.php
@@ -329,8 +329,8 @@ if (isset($_GET['scheduled_ticket_get_json_details'])) {
     $client_id = intval($_GET['client_id']);
     $ticket_id = intval($_GET['ticket_id']);
 
-    $contact_sql = mysqli_query($mysqli, "SELECT contact_id, contact_name FROM contacts 
-    WHERE contact_client_id = $client_id 
+    $contact_sql = mysqli_query($mysqli, "SELECT contact_id, contact_name FROM contacts
+    WHERE contact_client_id = $client_id
     AND contact_archived_at IS NULL
     ORDER BY contact_primary DESC, contact_technical DESC, contact_name ASC"
     );

--- a/js/scheduled_tickets_edit_modal.js
+++ b/js/scheduled_tickets_edit_modal.js
@@ -10,6 +10,7 @@ function populateScheduledTicketEditModal(client_id, ticket_id) {
             const response = JSON.parse(data);
 
             // Access the ticket info, and all potential assets
+            const contacts = response.contacts;
             const ticket = response.ticket[0];
             const assets = response.assets;
 
@@ -21,6 +22,27 @@ function populateScheduledTicketEditModal(client_id, ticket_id) {
             document.getElementById("editTicketNextRun").value = ticket.scheduled_ticket_next_run;
             tinyMCE.get('editTicketDetails').setContent(ticket.scheduled_ticket_details);
 
+            // Contact dropdown
+            var contactDropdown = document.getElementById("editTicketContact");
+
+            // Clear contact dropdown
+            var i, L = contactDropdown.options.length -1;
+            for(i = L; i >= 0; i--) {
+                contactDropdown.remove(i);
+            }
+            contactDropdown[contactDropdown.length] = new Option('- Contact -', '0');
+
+
+            // Populate dropdown
+            contacts.forEach(contact => {
+                if(parseInt(contact.contact_id) == parseInt(ticket.scheduled_ticket_contact_id)){
+                    // Selected contact
+                    contactDropdown[contactDropdown.length] = new Option(contact.contact_name, contact.contact_id, true, true);
+                }
+                else{
+                    contactDropdown[contactDropdown.length] = new Option(contact.contact_name, contact.contact_id);
+                }
+            });
 
             // Frequency dropdown
             var frequencyDropdown = document.querySelector("#editTicketFrequency");

--- a/post/ticket.php
+++ b/post/ticket.php
@@ -211,7 +211,7 @@ if (isset($_POST['add_ticket_watcher'])) {
     $client_id = intval($_POST['client_id']);
     $ticket_number = sanitizeInput($_POST['ticket_number']);
     $watcher_email = sanitizeInput($_POST['watcher_email']);
-    
+
     mysqli_query($mysqli,"INSERT INTO ticket_watchers SET watcher_email = '$watcher_email', watcher_ticket_id = $ticket_id");
 
     //Logging
@@ -963,8 +963,15 @@ if (isset($_POST['edit_scheduled_ticket'])) {
     $scheduled_ticket_id = intval($_POST['scheduled_ticket_id']);
     $next_run_date = sanitizeInput($_POST['next_date']);
 
+    // If no contact is selected automatically choose the primary contact for the client
+    if ($client_id > 0 && $contact_id == 0) {
+        $sql = mysqli_query($mysqli,"SELECT contact_id FROM contacts WHERE contact_client_id = $client_id AND contact_primary = 1");
+        $row = mysqli_fetch_array($sql);
+        $contact_id = intval($row['contact_id']);
+    }
+
     // Edit scheduled ticket
-    mysqli_query($mysqli, "UPDATE scheduled_tickets SET scheduled_ticket_subject = '$subject', scheduled_ticket_details = '$details', scheduled_ticket_priority = '$priority', scheduled_ticket_frequency = '$frequency', scheduled_ticket_next_run = '$next_run_date', scheduled_ticket_asset_id = $asset_id WHERE scheduled_ticket_id = $scheduled_ticket_id");
+    mysqli_query($mysqli, "UPDATE scheduled_tickets SET scheduled_ticket_subject = '$subject', scheduled_ticket_details = '$details', scheduled_ticket_priority = '$priority', scheduled_ticket_frequency = '$frequency', scheduled_ticket_next_run = '$next_run_date', scheduled_ticket_asset_id = $asset_id, scheduled_ticket_contact_id = $contact_id WHERE scheduled_ticket_id = $scheduled_ticket_id");
 
     // Logging
     mysqli_query($mysqli, "INSERT INTO logs SET log_type = 'Scheduled Ticket', log_action = 'Modify', log_description = '$session_name modified scheduled ticket for $subject - $frequency', log_ip = '$session_ip', log_user_agent = '$session_user_agent', log_client_id = $client_id, log_user_id = $session_user_id, log_entity_id = $scheduled_ticket_id");

--- a/scheduled_ticket_edit_modal.php
+++ b/scheduled_ticket_edit_modal.php
@@ -13,6 +13,18 @@
                     <input type="hidden" name="client" id="editClientId">
 
                     <div class="form-group">
+                        <label>Contact <strong class="text-danger">*</strong></label>
+                        <div class="input-group">
+                            <div class="input-group-prepend">
+                                <span class="input-group-text"><i class="fa fa-fw fa-user"></i></span>
+                            </div>
+                            <select class="form-control select2" name="contact" id="editTicketContact" required>
+                                <option value="">- Contact -</option>
+                            </select>
+                        </div>
+                    </div>
+
+                    <div class="form-group">
                         <label>Frequency <strong class="text-danger">*</strong></label>
                         <div class="input-group">
                             <div class="input-group-prepend">


### PR DESCRIPTION
This PR allows you to edit the contact for a scheduled ticket after it has been created. If no contact is selected, it defaults back to the primary contact.

_Future work: The client-specific scheduled ticket creation page allows you to set the contact when you initially create the ticket. We should add functionality for contact selection on main scheduled ticket creation page too._