### PR TITLE
Fix undefined client_is_lead errors

### DIFF
--- a/inc_all_client.php
+++ b/inc_all_client.php
@@ -32,6 +32,7 @@ if (isset($_GET['client_id'])) {
 
         $row = mysqli_fetch_array($sql);
         $client_name = nullable_htmlentities($row['client_name']);
+        $client_is_lead = intval($row['client_lead']);
         $client_type = nullable_htmlentities($row['client_type']);
         $client_website = nullable_htmlentities($row['client_website']);
         $client_referral = nullable_htmlentities($row['client_referral']);


### PR DESCRIPTION
- Defines client_is_lead within the general client include file to prevent the following error filling up logs on almost every page load.
> "PHP Notice: Undefined variable: client_is_lead in itflow/client_edit_modal.php on line 111"

![image](https://github.com/itflow-org/itflow/assets/32306651/d1e7a6c3-14d6-4f2f-b665-8dfb3116d48f)
