### PR TITLE
footer.php: reset values in all modals after they are hidden

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -12,7 +12,8 @@
 <!-- reset values in modals after hiding/dismissal -->
 <script>
 $(document).ready(function() {
-    $('body').on('hidden.bs.modal', '.modal', function () {
+    // exclude modals having an ID starting with 'add'
+    $('body').on('hidden.bs.modal', 'div.modal:not([id^="add"])', function () {
        // reset the form
        $(this).find('form').trigger('reset');
     });

--- a/footer.php
+++ b/footer.php
@@ -9,6 +9,16 @@
 </div>
 <!-- ./wrapper -->
 
+<!-- reset values in modals after hiding/dismissal -->
+<script>
+$(document).ready(function() {
+    $('body').on('hidden.bs.modal', '.modal', function () {
+       // reset the form
+       $(this).find('form').trigger('reset');
+    });
+});
+</script>
+
 <!-- REQUIRED SCRIPTS -->
 
 <!-- Bootstrap 4 -->


### PR DESCRIPTION
If a modal is hidden or dismissed (cancelled), any modified (but unsaved) values persist when the modal is opened again with the same record.

This change resets the modal when it is hidden so that saved values are shown the next time the modal is opened.