### PR TITLE
Enable passing stripe fee to clients

### DIFF
--- a/database_updates.php
+++ b/database_updates.php
@@ -1498,12 +1498,12 @@ if (LATEST_DATABASE_VERSION > CURRENT_DATABASE_VERSION) {
 
     }
 
-    //if (CURRENT_DATABASE_VERSION == '0.9.4') {
+    if (CURRENT_DATABASE_VERSION == '0.9.4') {
         // Insert queries here required to update to DB version 0.9.5
-
+        mysqli_query($mysqli, "ALTER TABLE `settings` ADD `config_stripe_client_pays_fees` TINYINT(1) NOT NULL DEFAULT 0 AFTER `config_stripe_account`"); 
         // Then, update the database to the next sequential version
-    //    mysqli_query($mysqli, "UPDATE `settings` SET `config_current_database_version` = '0.9.5'");
-    //}
+        mysqli_query($mysqli, "UPDATE `settings` SET `config_current_database_version` = '0.9.5'");
+    }
 } else {
     // Up-to-date
 }

--- a/database_version.php
+++ b/database_version.php
@@ -5,5 +5,5 @@
  * It is used in conjunction with database_updates.php
  */
 
-DEFINE("LATEST_DATABASE_VERSION", "0.9.4");
+DEFINE("LATEST_DATABASE_VERSION", "0.9.5");
 

--- a/db.sql
+++ b/db.sql
@@ -1267,6 +1267,7 @@ CREATE TABLE `settings` (
   `config_stripe_publishable` varchar(255) DEFAULT NULL,
   `config_stripe_secret` varchar(255) DEFAULT NULL,
   `config_stripe_account` tinyint(1) NOT NULL DEFAULT 0,
+  `config_stripe_client_pays_fees` tinyint(1) NOT NULL DEFAULT 0,
   `config_azure_client_id` varchar(200) DEFAULT NULL,
   `config_azure_client_secret` varchar(200) DEFAULT NULL,
   `config_module_enable_itdoc` tinyint(1) NOT NULL DEFAULT 1,

--- a/get_settings.php
+++ b/get_settings.php
@@ -84,6 +84,7 @@ $config_stripe_enable = intval($row['config_stripe_enable']);
 $config_stripe_publishable = $row['config_stripe_publishable'];
 $config_stripe_secret = $row['config_stripe_secret'];
 $config_stripe_account = $row['config_stripe_account'];
+$config_stripe_client_pays_fees = intval($row['config_stripe_client_pays_fees']);
 
 // Modules
 $config_module_enable_itdoc = intval($row['config_module_enable_itdoc']);

--- a/guest_ajax.php
+++ b/guest_ajax.php
@@ -57,6 +57,17 @@ if (isset($_GET['stripe_create_pi'])) {
     $amount_paid = floatval($row['amount_paid']);
     $balance_to_pay = $invoice_amount - $amount_paid;
 
+    // Check config to see if client pays fees is enabled
+    $row = mysqli_fetch_array(mysqli_query($mysqli, "SELECT config_stripe_client_pays_fees FROM settings WHERE company_id = 1"));
+    if ($row['config_client_pays_fees'] == 1) {
+        // Get fees from config
+        $row = mysqli_fetch_array(mysqli_query($mysqli, "SELECT config_stripe_percentage_fee, config_stripe_flat_fee FROM settings WHERE company_id = 1"));
+        $percentageFee = floatval($row['config_stripe_percentage_fee']);
+        $flatFee = floatval($row['config_stripe_flat_fee']);
+        // Calculate the amount to charge the client
+        $balance_to_pay = ($balance_to_pay + $flatFee) / (1 - $percentageFee);
+    }
+
     if (intval($balance_to_pay) == 0) {
         exit("No balance outstanding");
     }

--- a/post/setting.php
+++ b/post/setting.php
@@ -1098,3 +1098,19 @@ if (isset($_GET['update_db'])) {
 
     header("Location: " . $_SERVER["HTTP_REFERER"]);
 }
+
+if (isset($_POST['config_stripe_client_pays_fees'])) {
+
+    validateAdminRole();
+
+    $config_stripe_client_pays_fees = intval($_POST['config_stripe_client_pays_fees']);
+
+    mysqli_query($mysqli,"UPDATE settings SET config_stripe_client_pays_fees = $config_stripe_client_pays_fees WHERE company_id = 1");
+
+    //Logging
+    mysqli_query($mysqli,"INSERT INTO logs SET log_type = 'Settings', log_action = 'Modify', log_description = '$session_name modified stripe client pays fees', log_ip = '$session_ip', log_user_agent = '$session_user_agent', log_user_id = $session_user_id");
+
+    $_SESSION['alert_message'] = "Stripe client pays fees updated";
+
+    header("Location: " . $_SERVER["HTTP_REFERER"]);
+}

--- a/settings_online_payment.php
+++ b/settings_online_payment.php
@@ -2,6 +2,8 @@
 
 require_once "inc_all_settings.php";
 
+// Get Stripe Setting for config client pays
+
 
 ?>
 
@@ -61,10 +63,15 @@ require_once "inc_all_settings.php";
                                 }
                                 ?>
                             </select>
-
-
                         </div>
                     </div>
+                    <div class="form-group">
+                        <label>Client Pays Fees</label>
+                        <div class="custom-control custom-switch">
+                            <input type="checkbox" class="custom-control-input" name="config_stripe_client_pays_fees" <?php if ($config_stripe_client_pays_fees == 1) { echo "checked"; } ?> value="1" id="clientPaysFeesSwitch">
+                            <label class="custom-control-label" for="clientPaysFeesSwitch">Enable</label>
+                    </div>
+
 
                 <?php } ?>
 

--- a/settings_online_payment.php
+++ b/settings_online_payment.php
@@ -2,8 +2,6 @@
 
 require_once "inc_all_settings.php";
 
-// Get Stripe Setting for config client pays
-
 
 ?>
 


### PR DESCRIPTION
This pull request updates the database version to 0.9.5 and adds a new field called config_stripe_client_pays_fees to the settings table. This field allows the configuration of whether the client should pay the fees for Stripe transactions. This feature is useful for cases where the client wants to cover the transaction fees instead of the business.