### PR TITLE
Temporarily disable the personal dashboard link to prevent confusion

### DIFF
--- a/dashboard_nav.php
+++ b/dashboard_nav.php
@@ -1,7 +1,7 @@
 <div class="row mb-3">
 	<div class="col-md-12">
 		<div class="btn-group btn-group-lg btn-block">
-			<a href="dashboard.php" class="btn btn-<?php if (basename($_SERVER["PHP_SELF"]) == "dashboard.php") { echo "dark"; } else { echo "secondary"; } ?>">Personal <small>(WIP)</small></a>
+			<a style="pointer-events: none" href="dashboard.php" class="btn btn-<?php if (basename($_SERVER["PHP_SELF"]) == "dashboard.php") { echo "dark"; } else { echo "secondary"; } ?>">Personal <small>(coming soon)</small></a>
 			<?php if($config_module_enable_accounting == 1) { ?>
 			<a href="dashboard_financial.php" class="btn btn-<?php if (basename($_SERVER["PHP_SELF"]) == "dashboard_financial.php") { echo "dark"; } else { echo "secondary"; } ?>">Administrative</a>
 			<?php } ?>


### PR DESCRIPTION
Temporarily disable the personal dashboard link to prevent confusion, as it is not yet in use