### PR TITLE
Require CSRF token to edit more admin settings

### DIFF
--- a/post/setting.php
+++ b/post/setting.php
@@ -6,6 +6,7 @@
 
 if (isset($_POST['edit_company'])) {
 
+    validateCSRFToken($_POST['csrf_token']);
     validateAdminRole();
 
     require_once 'post/setting_company_model.php';
@@ -53,6 +54,7 @@ if (isset($_POST['edit_company'])) {
 
 if (isset($_POST['edit_localization'])) {
 
+    validateCSRFToken($_POST['csrf_token']);
     validateAdminRole();
 
     $locale = sanitizeInput($_POST['locale']);
@@ -74,6 +76,7 @@ if (isset($_POST['edit_localization'])) {
 
 if (isset($_POST['edit_mail_smtp_settings'])) {
 
+    validateCSRFToken($_POST['csrf_token']);
     validateAdminRole();
 
     $config_smtp_host = sanitizeInput($_POST['config_smtp_host']);
@@ -95,6 +98,7 @@ if (isset($_POST['edit_mail_smtp_settings'])) {
 
 if (isset($_POST['edit_mail_imap_settings'])) {
 
+    validateCSRFToken($_POST['csrf_token']);
     validateAdminRole();
 
     $config_imap_host = sanitizeInput($_POST['config_imap_host']);
@@ -117,6 +121,7 @@ if (isset($_POST['edit_mail_imap_settings'])) {
 
 if (isset($_POST['edit_mail_from_settings'])) {
 
+    validateCSRFToken($_POST['csrf_token']);
     validateAdminRole();
 
     $config_mail_from_email = sanitizeInput($_POST['config_mail_from_email']);
@@ -144,6 +149,7 @@ if (isset($_POST['edit_mail_from_settings'])) {
 
 if (isset($_POST['test_email_smtp'])) {
 
+    validateCSRFToken($_POST['csrf_token']);
     validateAdminRole();
     $email_from = sanitizeInput($_POST['email_from']);
     $email_to = sanitizeInput($_POST['email_to']);
@@ -167,6 +173,7 @@ if (isset($_POST['test_email_smtp'])) {
 
 if (isset($_POST['test_email_imap'])) {
 
+    validateCSRFToken($_POST['csrf_token']);
     validateAdminRole();
 
     // Prepare connection string with encryption (TLS/SSL/<blank>)
@@ -188,6 +195,7 @@ if (isset($_POST['test_email_imap'])) {
 
 if (isset($_POST['edit_invoice_settings'])) {
 
+    validateCSRFToken($_POST['csrf_token']);
     validateAdminRole();
 
     $config_invoice_prefix = sanitizeInput($_POST['config_invoice_prefix']);
@@ -212,6 +220,7 @@ if (isset($_POST['edit_invoice_settings'])) {
 
 if (isset($_POST['edit_quote_settings'])) {
 
+    validateCSRFToken($_POST['csrf_token']);
     validateAdminRole();
 
     $config_quote_prefix = sanitizeInput($_POST['config_quote_prefix']);
@@ -254,6 +263,7 @@ if (isset($_POST['edit_ticket_settings'])) {
 
 if (isset($_POST['edit_default_settings'])) {
 
+    validateCSRFToken($_POST['csrf_token']);
     validateAdminRole();
 
     $start_page = sanitizeInput($_POST['start_page']);
@@ -279,6 +289,7 @@ if (isset($_POST['edit_default_settings'])) {
 
 if (isset($_POST['edit_theme_settings'])) {
 
+    validateCSRFToken($_POST['csrf_token']);
     validateAdminRole();
 
     $theme = preg_replace("/[^0-9a-zA-Z-]/", "", sanitizeInput($_POST['theme']));
@@ -295,6 +306,7 @@ if (isset($_POST['edit_theme_settings'])) {
 
 if (isset($_POST['edit_alert_settings'])) {
 
+    validateCSRFToken($_POST['csrf_token']);
     validateAdminRole();
 
     $config_enable_cron = intval($_POST['config_enable_cron']);
@@ -351,6 +363,7 @@ if (isset($_POST['edit_online_payment_settings'])) {
 
 if (isset($_POST['edit_integrations_settings'])) {
 
+    validateCSRFToken($_POST['csrf_token']);
     validateAdminRole();
 
     $azure_client_id = sanitizeInput($_POST['azure_client_id']);
@@ -388,6 +401,8 @@ if (isset($_POST['edit_module_settings'])) {
 }
 
 if (isset($_POST['edit_security_settings'])) {
+
+    validateCSRFToken($_POST['csrf_token']);
     validateAdminRole();
 
     $config_login_message = sanitizeInput($_POST['config_login_message']);
@@ -406,6 +421,7 @@ if (isset($_POST['edit_security_settings'])) {
 
 if (isset($_POST['edit_telemetry_settings'])) {
 
+    validateCSRFToken($_POST['csrf_token']);
     validateAdminRole();
 
     $config_telemetry = intval($_POST['config_telemetry']);
@@ -697,6 +713,7 @@ if (isset($_POST['send_telemetry_data'])) {
 
 if (isset($_GET['download_database'])) {
 
+    validateCSRFToken($_GET['csrf_token']);
     validateAdminRole();
 
     // Get All Table Names From the Database

--- a/post/tax.php
+++ b/post/tax.php
@@ -6,6 +6,7 @@
 
 if (isset($_POST['add_tax'])) {
 
+    validateCSRFToken($_POST['csrf_token']);
     $name = sanitizeInput($_POST['name']);
     $percent = floatval($_POST['percent']);
 
@@ -22,6 +23,7 @@ if (isset($_POST['add_tax'])) {
 
 if (isset($_POST['edit_tax'])) {
 
+    validateCSRFToken($_POST['csrf_token']);
     $tax_id = intval($_POST['tax_id']);
     $name = sanitizeInput($_POST['name']);
     $percent = floatval($_POST['percent']);
@@ -38,6 +40,7 @@ if (isset($_POST['edit_tax'])) {
 }
 
 if (isset($_GET['archive_tax'])) {
+    validateCSRFToken($_GET['csrf_token']);
     $tax_id = intval($_GET['archive_tax']);
 
     mysqli_query($mysqli,"UPDATE taxes SET tax_archived_at = NOW() WHERE tax_id = $tax_id");

--- a/settings_alerts.php
+++ b/settings_alerts.php
@@ -8,6 +8,7 @@ require_once "inc_all_settings.php";
         </div>
         <div class="card-body">
             <form action="post.php" method="post" autocomplete="off">
+                <input type="hidden" name="csrf_token" value="<?php echo $_SESSION['csrf_token'] ?>">
 
                 <div class="form-group">
                     <div class="custom-control custom-switch">

--- a/settings_backup.php
+++ b/settings_backup.php
@@ -7,7 +7,7 @@ require_once "inc_all_settings.php";
             <h3 class="card-title"><i class="fas fa-fw fa-database mr-2"></i>Download Database</h3>
         </div>
         <div class="card-body" style="text-align: center;">
-            <a class="btn btn-primary btn-lg p-3" href="post.php?download_database"><i class="fas fa-fw fa-4x fa-download"></i><br><br>Download</a>
+            <a class="btn btn-primary btn-lg p-3" href="post.php?download_database&csrf_token=<?php echo $_SESSION['csrf_token'] ?>"><i class="fas fa-fw fa-4x fa-download"></i><br><br>Download</a>
         </div>
     </div>
 

--- a/settings_company.php
+++ b/settings_company.php
@@ -29,6 +29,7 @@ $company_initials = nullable_htmlentities(initials($company_name));
         </div>
         <div class="card-body">
             <form action="post.php" method="post" enctype="multipart/form-data" autocomplete="off">
+                <input type="hidden" name="csrf_token" value="<?php echo $_SESSION['csrf_token'] ?>">
 
                 <div class="form-group">
                     <label>Name <strong class="text-danger">*</strong></label>

--- a/settings_defaults.php
+++ b/settings_defaults.php
@@ -9,6 +9,7 @@ require_once "inc_all_settings.php";
     </div>
     <div class="card-body">
         <form action="post.php" method="post" autocomplete="off">
+            <input type="hidden" name="csrf_token" value="<?php echo $_SESSION['csrf_token'] ?>">
 
             <div class="form-group">
                 <label>Start Page</label>
@@ -21,7 +22,7 @@ require_once "inc_all_settings.php";
                             <option selected> <?php echo nullable_htmlentities($config_start_page); ?></option>
                         <?php } ?>
                         <?php foreach ($start_page_select_array as $start_page_value => $start_page_name) { ?>
-                            <option <?php if ($start_page_value == $config_start_page) { echo "selected"; } ?> 
+                            <option <?php if ($start_page_value == $config_start_page) { echo "selected"; } ?>
                                 value="<?php echo nullable_htmlentities($start_page_value); ?>">
                                 <?php echo nullable_htmlentities($start_page_name); ?>
                             </option>

--- a/settings_integrations.php
+++ b/settings_integrations.php
@@ -8,6 +8,7 @@ require_once "inc_all_settings.php";
         </div>
         <div class="card-body">
             <form action="post.php" method="post" autocomplete="off">
+                <input type="hidden" name="csrf_token" value="<?php echo $_SESSION['csrf_token'] ?>">
 
                 <h4>Client Portal SSO via Microsoft Azure AD</h4>
                 <div class="form-group">

--- a/settings_invoice.php
+++ b/settings_invoice.php
@@ -8,6 +8,7 @@ require_once "inc_all_settings.php";
         </div>
         <div class="card-body">
             <form action="post.php" method="post" autocomplete="off">
+                <input type="hidden" name="csrf_token" value="<?php echo $_SESSION['csrf_token'] ?>">
 
                 <h4>Invoice</h4>
 

--- a/settings_localization.php
+++ b/settings_localization.php
@@ -19,6 +19,7 @@ $timezones = DateTimeZone::listIdentifiers();
         </div>
         <div class="card-body">
             <form action="post.php" method="post" autocomplete="off">
+                <input type="hidden" name="csrf_token" value="<?php echo $_SESSION['csrf_token'] ?>">
 
                 <div class="form-group">
                     <label>Language <strong class="text-danger">*</strong></label>

--- a/settings_mail.php
+++ b/settings_mail.php
@@ -8,6 +8,7 @@ require_once "inc_all_settings.php";
         </div>
         <div class="card-body">
             <form action="post.php" method="post" autocomplete="off">
+                <input type="hidden" name="csrf_token" value="<?php echo $_SESSION['csrf_token'] ?>">
 
                 <div class="form-group">
                     <label>SMTP Host</label>
@@ -80,6 +81,7 @@ require_once "inc_all_settings.php";
         </div>
         <div class="card-body">
             <form action="post.php" method="post" autocomplete="off">
+                <input type="hidden" name="csrf_token" value="<?php echo $_SESSION['csrf_token'] ?>">
 
                 <div class="form-group">
                     <label>IMAP Host</label>
@@ -154,6 +156,8 @@ require_once "inc_all_settings.php";
         </div>
         <div class="card-body">
             <form action="post.php" method="post" autocomplete="off">
+                <input type="hidden" name="csrf_token" value="<?php echo $_SESSION['csrf_token'] ?>">
+
                 <p>Each of the "From Email" Addresses need to be able to send email on behalf of the SMTP user configured above
                 <h5>System Default</h5>
                 <p class="text-secondary">(used for system tasks such as sending share links)</p>
@@ -262,6 +266,8 @@ require_once "inc_all_settings.php";
         </div>
         <div class="card-body">
             <form action="post.php" method="post" autocomplete="off">
+                <input type="hidden" name="csrf_token" value="<?php echo $_SESSION['csrf_token'] ?>">
+
                 <div class="input-group">
                     <select class="form-control select2" name="email_from" required>
                         <option value="">- Select an Email Address to send from -</option>
@@ -308,6 +314,8 @@ require_once "inc_all_settings.php";
         </div>
         <div class="card-body">
             <form action="post.php" method="post" autocomplete="off">
+                <input type="hidden" name="csrf_token" value="<?php echo $_SESSION['csrf_token'] ?>">
+
                 <div class="input-group-append">
                     <button type="submit" name="test_email_imap" class="btn btn-success"><i class="fas fa-fw fa-inbox mr-2"></i>Test</button>
                 </div>

--- a/settings_modules.php
+++ b/settings_modules.php
@@ -8,6 +8,7 @@ require_once "inc_all_settings.php";
         </div>
         <div class="card-body">
             <form action="post.php" method="post" autocomplete="off">
+                <input type="hidden" name="csrf_token" value="<?php echo $_SESSION['csrf_token'] ?>">
 
                 <div class="form-group">
                     <div class="custom-control custom-switch">

--- a/settings_quote.php
+++ b/settings_quote.php
@@ -8,6 +8,7 @@ require_once "inc_all_settings.php";
         </div>
         <div class="card-body">
             <form action="post.php" method="post" autocomplete="off">
+                <input type="hidden" name="csrf_token" value="<?php echo $_SESSION['csrf_token'] ?>">
 
                 <div class="form-group">
                     <label>Quote Prefix</label>

--- a/settings_security.php
+++ b/settings_security.php
@@ -9,6 +9,7 @@ require_once "inc_all_settings.php";
         </div>
         <div class="card-body">
             <form action="post.php" method="post" autocomplete="off">
+                <input type="hidden" name="csrf_token" value="<?php echo $_SESSION['csrf_token'] ?>">
 
                 <div class="form-group">
                     <label>Login Message</label>

--- a/settings_tax_add_modal.php
+++ b/settings_tax_add_modal.php
@@ -8,6 +8,8 @@
         </button>
       </div>
       <form action="post.php" method="post" autocomplete="off">
+        <input type="hidden" name="csrf_token" value="<?php echo $_SESSION['csrf_token'] ?>">
+
         <div class="modal-body bg-white">
           <div class="form-group">
             <label>Name <strong class="text-danger">*</strong></label>

--- a/settings_tax_edit_modal.php
+++ b/settings_tax_edit_modal.php
@@ -8,20 +8,22 @@
         </button>
       </div>
       <form action="post.php" method="post" autocomplete="off">
+        <input type="hidden" name="csrf_token" value="<?php echo $_SESSION['csrf_token'] ?>">
         <input type="hidden" name="tax_id" value="<?php echo $tax_id; ?>">
+
         <div class="modal-body bg-white">
-          
+
           <div class="form-group">
             <label>Name <strong class="text-danger">*</strong></label>
             <input type="text" class="form-control" name="name" value="<?php echo $tax_name; ?>" required>
           </div>
-          
+
           <div class="form-group">
             <label>Percent <strong class="text-danger">*</strong></label>
             <input type="number" min="0" step="any" class="form-control col-md-4" name="percent" value="<?php echo $tax_percent; ?>">
-          
+
           </div>
-        
+
         </div>
         <div class="modal-footer bg-white">
           <button type="submit" name="edit_tax" class="btn btn-primary text-bold"><i class="fas fa-check mr-2"></i>Save</button>

--- a/settings_taxes.php
+++ b/settings_taxes.php
@@ -11,7 +11,7 @@ require_once "inc_all_settings.php";
 $url_query_strings_sort = http_build_query($get_copy);
 
 $sql = mysqli_query(
-    $mysqli, 
+    $mysqli,
     "SELECT * FROM taxes
     WHERE tax_archived_at IS NULL
     ORDER BY $sort $order"
@@ -60,7 +60,7 @@ $num_rows = mysqli_num_rows($sql);
                                             <i class="fas fa-fw fa-edit mr-2"></i>Edit
                                         </a>
                                         <div class="dropdown-divider"></div>
-                                        <a class="dropdown-item text-danger confirm-link" href="post.php?archive_tax=<?php echo $tax_id; ?>">
+                                        <a class="dropdown-item text-danger confirm-link" href="post.php?archive_tax=<?php echo $tax_id; ?>&csrf_token=<?php echo $_SESSION['csrf_token'] ?>">
                                             <i class="fas fa-fw fa-archive mr-2"></i>Archive
                                         </a>
                                     </div>

--- a/settings_telemetry.php
+++ b/settings_telemetry.php
@@ -11,6 +11,7 @@ require_once "inc_all_settings.php";
             <p class="text-center">Installation ID: <strong><?php echo $installation_id; ?></strong></p>
 
             <form action="post.php" method="post" autocomplete="off">
+                <input type="hidden" name="csrf_token" value="<?php echo $_SESSION['csrf_token'] ?>">
 
                 <div class="form-group">
                     <label>Telemetry</label>

--- a/settings_theme.php
+++ b/settings_theme.php
@@ -8,6 +8,7 @@ require_once "inc_all_settings.php";
         </div>
         <div class="card-body">
             <form action="post.php" method="post" autocomplete="off">
+                <input type="hidden" name="csrf_token" value="<?php echo $_SESSION['csrf_token'] ?>">
 
                 <label>Select a Theme</label>
                 <div class="form-row">

--- a/settings_ticket.php
+++ b/settings_ticket.php
@@ -8,6 +8,7 @@ require_once "inc_all_settings.php";
         </div>
         <div class="card-body">
             <form action="post.php" method="post" autocomplete="off">
+                <input type="hidden" name="csrf_token" value="<?php echo $_SESSION['csrf_token'] ?>">
 
                 <div class="form-group">
                     <label>Ticket Prefix</label>


### PR DESCRIPTION
This PR requires the CSRF token for the majority of the admin settings forms/actions.

With thanks again to @stehled