### PR TITLE
Bugfix: New locations are set as the primary

### DIFF
--- a/client_location_add_modal.php
+++ b/client_location_add_modal.php
@@ -38,7 +38,7 @@
                                     <input type="text" class="form-control" name="name" placeholder="Name of location" required autofocus>
                                     <div class="input-group-append">
                                         <div class="input-group-text">
-                                            <input type="checkbox" name="location_primary" value="1" <?php if ($location_primary == 0) { echo "checked"; } ?>>
+                                            <input type="checkbox" name="location_primary" value="1">
                                         </div>
                                     </div>
                                 </div>


### PR DESCRIPTION
Bugfix: Every time you add a new location, it is marked as the primary location in the modal by default as the location_primary variable is overwritten with each iteration of a location. This PR defaults to no location being the primary, to avoid unnecessarily overwriting the primary location.

Future work: Re-add fixed logic used to determine if a primary location is missing