### PR TITLE
Fix ticket_assigned_to filter in SQL query

### DIFF
--- a/tickets.php
+++ b/tickets.php
@@ -1,5 +1,6 @@
 <?php
 
+
 // Default Column Sortby Filter
 $sort = "ticket_number";
 $order = "DESC";
@@ -36,9 +37,9 @@ if (isset($_GET['status']) && is_array($_GET['status']) && !empty($_GET['status'
 // Ticket assignment status filter
 if (isset($_GET['assigned']) & !empty($_GET['assigned'])) {
     if ($_GET['assigned'] == 'unassigned') {
-        $ticket_assigned_filter = '0';
+        $ticket_assigned_filter = 'AND ticket_assigned_to = 0';
     } else {
-        $ticket_assigned_filter = intval($_GET['assigned']);
+        $ticket_assigned_filter = 'AND ticket_assigned_to = '.intval($_GET['assigned']);
     }
 } else {
     // Default - any
@@ -58,8 +59,7 @@ $sql = mysqli_query(
     LEFT JOIN assets ON ticket_asset_id = asset_id
     LEFT JOIN locations ON ticket_location_id = location_id
     LEFT JOIN vendors ON ticket_vendor_id = vendor_id
-    WHERE ticket_assigned_to LIKE '$ticket_assigned_filter'
-    AND $ticket_status_snippet
+    WHERE $ticket_status_snippet " . $ticket_assigned_filter . "
     AND DATE(ticket_created_at) BETWEEN '$dtf' AND '$dtt'
     AND (CONCAT(ticket_prefix,ticket_number) LIKE '%$q%' OR client_name LIKE '%$q%' OR ticket_subject LIKE '%$q%' OR ticket_status LIKE '%$q%' OR ticket_priority LIKE '%$q%' OR user_name LIKE '%$q%' OR contact_name LIKE '%$q%' OR asset_name LIKE '%$q%' OR vendor_name LIKE '%$q%' OR ticket_vendor_ticket_number LIKE '%q%')
     ORDER BY $sort $order LIMIT $record_from, $record_to"

--- a/tickets.php
+++ b/tickets.php
@@ -58,7 +58,7 @@ $sql = mysqli_query(
     LEFT JOIN assets ON ticket_asset_id = asset_id
     LEFT JOIN locations ON ticket_location_id = location_id
     LEFT JOIN vendors ON ticket_vendor_id = vendor_id
-    WHERE ticket_assigned_to LIKE '%$ticket_assigned_filter%'
+    WHERE ticket_assigned_to LIKE '$ticket_assigned_filter'
     AND $ticket_status_snippet
     AND DATE(ticket_created_at) BETWEEN '$dtf' AND '$dtt'
     AND (CONCAT(ticket_prefix,ticket_number) LIKE '%$q%' OR client_name LIKE '%$q%' OR ticket_subject LIKE '%$q%' OR ticket_status LIKE '%$q%' OR ticket_priority LIKE '%$q%' OR user_name LIKE '%$q%' OR contact_name LIKE '%$q%' OR asset_name LIKE '%$q%' OR vendor_name LIKE '%$q%' OR ticket_vendor_ticket_number LIKE '%q%')


### PR DESCRIPTION
This pull request fixes the ticket_assigned_to filter in the SQL query. Previously, the filter was using the LIKE operator with a wildcard at the beginning and end of the filter value. This caused incorrect results when searching for specific users, as you would want. The fix removes the wildcard at the beginning and end of the filter value, ensuring accurate filtering based on the assigned_to field.