### PR TITLE
Redirect to tickets.php after deleting a ticket

### DIFF
--- a/post/ticket.php
+++ b/post/ticket.php
@@ -477,7 +477,7 @@ if (isset($_GET['delete_ticket'])) {
         $_SESSION['alert_type'] = "error";
         $_SESSION['alert_message'] = "Ticket <strong>$ticket_prefix$ticket_number</strong> along with all replies deleted";
 
-        header("Location: " . $_SERVER["HTTP_REFERER"]);
+        header("Location: tickets.php");
     }
 
 }


### PR DESCRIPTION
This pull request updates the redirect behavior after deleting a ticket. Instead of redirecting to the deleted ticket's page, it now redirects to the tickets.php page. This improves the user experience and ensures a smoother flow within the application.