### PR TITLE
Avoiding issue when unable to add domain

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -373,10 +373,11 @@ function encryptLoginEntry($login_password_cleartext)
 // Get domain expiration date
 function getDomainExpirationDate($name)
 {
-
+    $nullValue = "1000-01-01";
+    
     // Only run if we think the domain is valid
     if (!filter_var($name, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME)) {
-        return "NULL";
+        return $nullValue;
     }
 
     $ch = curl_init();
@@ -390,14 +391,14 @@ function getDomainExpirationDate($name)
         } elseif (isset($response['expiration_date'])) {
             $expiry = new DateTime($response['expiration_date']);
         } else {
-            return "NULL";
+            return $nullValue;
         }
-
+        
         return $expiry->format('Y-m-d');
     }
 
     // Default return
-    return "1000-01-01";
+    return $nullValue;
 }
 
 // Get domain general info (whois + NS/A/MX records)

--- a/functions.php
+++ b/functions.php
@@ -397,7 +397,7 @@ function getDomainExpirationDate($name)
     }
 
     // Default return
-    return "NULL";
+    return "1000-01-01";
 }
 
 // Get domain general info (whois + NS/A/MX records)


### PR DESCRIPTION
We were experiencing HTTP 500 when trying to add the following domains:

- solemaids.nl
- solemaids.com.au

The getDomainExpirationDate function returned NULL. The mySQL column isnt nullable.
Returning mySQL min date instead.