### PR TITLE
Domain expiration dates

### DIFF
--- a/cron.php
+++ b/cron.php
@@ -138,7 +138,7 @@ if($config_enable_alert_domain_expire == 1){
             $mysqli,
             "SELECT * FROM domains
             LEFT JOIN clients ON domain_client_id = client_id 
-            WHERE domain_expire = CURDATE() + INTERVAL $day DAY"
+            WHERE domain_expire IS NOT NULL AND domain_expire = CURDATE() + INTERVAL $day DAY"
         );
 
         while ($row = mysqli_fetch_array($sql)) {

--- a/cron_domain_refresher.php
+++ b/cron_domain_refresher.php
@@ -41,12 +41,20 @@ if ( $argv[1] !== $config_cron_key ) {
 // END ERROR
 // REFRESH DOMAIN WHOIS DATA (1 a day)
 //  Get the oldest updated domain (MariaDB shows NULLs first when ordering by default)
-$row = mysqli_fetch_array(mysqli_query($mysqli, "SELECT domain_id, domain_name FROM `domains` ORDER BY domain_updated_at LIMIT 1"));
+$row = mysqli_fetch_array(mysqli_query($mysqli, "SELECT domain_id, domain_name, domain_expire FROM `domains` ORDER BY domain_updated_at LIMIT 1"));
 
 if ($row) {
+
+    // Get current data in database
     $domain_id = intval($row['domain_id']);
     $domain_name = sanitizeInput($row['domain_name']);
+    $current_expire = sanitizeInput($row['domain_expire']);
 
+    echo "Renewing $domain_name";
+    // Touch the record we're refreshing to ensure we don't loop
+    mysqli_query($mysqli, "UPDATE domains SET domain_updated_at = NOW() WHERE domain_id = $domain_id");
+
+    // Lookup fresh info
     $expire = getDomainExpirationDate($domain_name);
     $records = getDomainRecords($domain_name);
     $a = sanitizeInput($records['a']);
@@ -55,16 +63,18 @@ if ($row) {
     $txt = sanitizeInput($records['txt']);
     $whois = sanitizeInput($records['whois']);
 
-    if (
-        $expire === 'NULL'
-        && $row['domain_expire'] !== null
-        && (new DateTime($row['domain_expire'])) >= (new DateTime())
-    ) {
-        $expire = $row['domain_expire'];
+    // Handle expiry date
+    if (strtotime($expire)) {
+        $expire = "'" . $expire . "'"; // Valid
+    } elseif (!strtotime($expire) && strtotime($current_expire)) {
+        // New expiry date is invalid, but old one is OK - reverting back
+        $expire = "'" . $current_expire . "'";
+    } else {
+        // Neither are valid, setting expiry to NULL
+        $expire = 'NULL';
     }
 
-    // Update the domain
-    mysqli_query($mysqli, "UPDATE domains SET domain_name = '$domain_name',  domain_expire = '$expire', domain_ip = '$a', domain_name_servers = '$ns', domain_mail_servers = '$mx', domain_txt = '$txt', domain_raw_whois = '$whois' WHERE domain_id = $domain_id");
-}
 
-// TODO: Re-add the cert refresher
+    // Update the domain
+    mysqli_query($mysqli, "UPDATE domains SET domain_name = '$domain_name',  domain_expire = $expire, domain_ip = '$a', domain_name_servers = '$ns', domain_mail_servers = '$mx', domain_txt = '$txt', domain_raw_whois = '$whois' WHERE domain_id = $domain_id");
+}

--- a/post/domain.php
+++ b/post/domain.php
@@ -16,16 +16,17 @@ if (isset($_POST['add_domain'])) {
     $expire = sanitizeInput($_POST['expire']);
     $notes = sanitizeInput($_POST['notes']);
 
-    if (empty($expire)) {
-        $expire = "NULL";
-    } else {
+    // Set/check/lookup expiry date
+    if (strtotime($expire)) {
         $expire = "'" . $expire . "'";
     }
-
-    // Get domain expiry date - if not specified
-    if ($expire == 'NULL') {
+    else {
         $expire = getDomainExpirationDate($name);
-        $expire = "'" . $expire . "'";
+        if (strtotime($expire)) {
+            $expire = "'" . $expire . "'";
+        } else {
+            $expire = 'NULL';
+        }
     }
 
     // NS, MX, A and WHOIS records/data
@@ -37,8 +38,7 @@ if (isset($_POST['add_domain'])) {
     $whois = sanitizeInput($records['whois']);
 
     // Add domain record
-    mysqli_query($mysqli,"INSERT INTO domains SET domain_name = '$name', domain_registrar = $registrar,  domain_webhost = $webhost, domain_expire = $expire, domain_ip = '$a', domain_name_servers = '$ns', domain_mail_servers = '$mx', domain_txt = '$txt', domain_raw_whois = '$whois', domain_notes = '$notes', domain_client_id = $client_id");
-
+    mysqli_query($mysqli,"INSERT INTO domains SET domain_name = '$name', domain_registrar = $registrar,  domain_webhost = $webhost, domain_expire = $expire, domain_ip = '$a', domain_name_servers = '$ns', domain_mail_servers = '$mx', domain_txt = '$txt', domain_raw_whois = '$whois', domain_notes = '$notes', domain_client_id = $client_id") or die(mysqli_error($mysqli));
 
     // Get inserted ID (for linking certificate, if exists)
     $domain_id = mysqli_insert_id($mysqli);
@@ -74,9 +74,22 @@ if (isset($_POST['edit_domain'])) {
     $expire = sanitizeInput($_POST['expire']);
     $notes = sanitizeInput($_POST['notes']);
 
-    if (empty($expire) || (new DateTime($expire)) < (new DateTime())) {
-        // Update domain expiry date
+//    if (empty($expire) || (new DateTime($expire)) < (new DateTime())) {
+//        // Update domain expiry date
+//        $expire = getDomainExpirationDate($name);
+//    }
+
+    // Set/check/lookup expiry date
+    if (strtotime($expire) && (new DateTime($expire)) > (new DateTime())) {
+        $expire = "'" . $expire . "'";
+    }
+    else {
         $expire = getDomainExpirationDate($name);
+        if (strtotime($expire)) {
+            $expire = "'" . $expire . "'";
+        } else {
+            $expire = 'NULL';
+        }
     }
 
     $client_id = intval($_POST['client_id']);
@@ -89,7 +102,7 @@ if (isset($_POST['edit_domain'])) {
     $txt = sanitizeInput($records['txt']);
     $whois = sanitizeInput($records['whois']);
 
-    mysqli_query($mysqli,"UPDATE domains SET domain_name = '$name', domain_registrar = $registrar,  domain_webhost = $webhost, domain_expire = '$expire', domain_ip = '$a', domain_name_servers = '$ns', domain_mail_servers = '$mx', domain_txt = '$txt', domain_raw_whois = '$whois', domain_notes = '$notes' WHERE domain_id = $domain_id");
+    mysqli_query($mysqli,"UPDATE domains SET domain_name = '$name', domain_registrar = $registrar,  domain_webhost = $webhost, domain_expire = $expire, domain_ip = '$a', domain_name_servers = '$ns', domain_mail_servers = '$mx', domain_txt = '$txt', domain_raw_whois = '$whois', domain_notes = '$notes' WHERE domain_id = $domain_id");
 
     //Logging
     mysqli_query($mysqli,"INSERT INTO logs SET log_type = 'Domain', log_action = 'Modify', log_description = '$session_name modified domain $name', log_ip = '$session_ip', log_user_agent = '$session_user_agent', log_client_id = $client_id, log_user_id = $session_user_id, log_entity_id = $domain_id");


### PR DESCRIPTION
- Update logic in post when adding/editing a domain to better account for null values
- Update logic in cron domain refresher to account for null values
- Prevent cron domain refresher getting stuck on a single domain
- Exclude domains with no expiration date from the cron nightly renewal alerts