### PR TITLE
Hide billable tickets when accounting is disabled

### DIFF
--- a/client_tickets.php
+++ b/client_tickets.php
@@ -122,7 +122,9 @@ $total_scheduled_tickets = intval($row['total_scheduled_tickets']);
                     <th><a class="text-dark" href="?<?php echo $url_query_strings_sort; ?>&sort=ticket_number&order=<?php echo $disp; ?>">Number</a></th>
                     <th><a class="text-dark" href="?<?php echo $url_query_strings_sort; ?>&sort=ticket_subject&order=<?php echo $disp; ?>">Subject</a></th>
                     <th><a class="text-dark" href="?<?php echo $url_query_strings_sort; ?>&sort=contact_name&order=<?php echo $disp; ?>">Contact</a></th>
-                    <th><a class="text-dark" href="?<?php echo $url_query_strings_sort; ?>&sort=ticket_billable&order=<?php echo $disp; ?>">Billable</a></th>
+                    <?php if ($config_module_enable_accounting) { ?>
+                        <th><a class="text-dark" href="?<?php echo $url_query_strings_sort; ?>&sort=ticket_billable&order=<?php echo $disp; ?>">Billable</a></th>
+                    <?php } ?>
                     <th><a class="text-dark" href="?<?php echo $url_query_strings_sort; ?>&sort=ticket_priority&order=<?php echo $disp; ?>">Priority</a></th>
                     <th><a class="text-dark" href="?<?php echo $url_query_strings_sort; ?>&sort=ticket_status&order=<?php echo $disp; ?>">Status</a></th>
                     <th><a class="text-dark" href="?<?php echo $url_query_strings_sort; ?>&sort=user_name&order=<?php echo $disp; ?>">Assigned</a></th>
@@ -220,15 +222,20 @@ $total_scheduled_tickets = intval($row['total_scheduled_tickets']);
                             <a href="ticket.php?ticket_id=<?php echo $ticket_id; ?>"><?php echo $ticket_subject; ?></a>
                         </td>
                         <td><a href="#" data-toggle="modal" data-target="#editTicketContactModal<?php echo $ticket_id; ?>"><?php echo $contact_display; ?></a></td>
+
+                        <?php if ($config_module_enable_accounting) { ?>
                         <td class="text-center">
                             <a href="#" data-toggle="modal" data-target="#editTicketBillableModal<?php echo $ticket_id; ?>">
                             <?php
-                        if ($ticket_billable == 1) {
-                            echo "<span class='badge badge-pill badge-success'>$</span>";
-                        } else {
-                            echo "<span class='badge badge-pill badge-secondary'>X</span>";
-                        }
-                        ?></td>
+                                if ($ticket_billable == 1) {
+                                    echo "<span class='badge badge-pill badge-success'>$</span>";
+                                } else {
+                                    echo "<span class='badge badge-pill badge-secondary'>X</span>";
+                                }
+                            ?>
+                        </td>
+                        <?php } ?>
+
                         <td><a href="#" data-toggle="modal" data-target="#editTicketPriorityModal<?php echo $ticket_id; ?>"><?php echo $ticket_priority_display; ?></a></td>
                         <td><span class='p-2 badge badge-pill badge-<?php echo $ticket_status_color; ?>'><?php echo $ticket_status; ?></span></td>
                         <td><a href="#" data-toggle="modal" data-target="#assignTicketModal<?php echo $ticket_id; ?>"><?php echo $ticket_assigned_to_display; ?></a></td>

--- a/tickets.php
+++ b/tickets.php
@@ -310,13 +310,10 @@ $user_active_assigned_tickets = intval($row['total_tickets_assigned']);
                             </th>
                             <th><a class="text-dark" href="?<?php echo $url_query_strings_sort; ?>&sort=client_name&order=<?php echo $disp; ?>">Client / Contact</a>
                             </th>
-                            <?php if ($config_module_enable_accounting) {
-                            ?>
+                            <?php if ($config_module_enable_accounting) { ?>
                                 <th class="text-center"><a class="text-dark" href="?<?php echo $url_query_strings_sort; ?>&sort=ticket_billable&order=<?php echo $disp; ?>">Billable</a>
                                 </th>
-                            <?php
-                            }
-                            ?>
+                            <?php } ?>
 
                             <th><a class="text-dark" href="?<?php echo $url_query_strings_sort; ?>&sort=ticket_priority&order=<?php echo $disp; ?>">Priority</a>
                             </th>


### PR DESCRIPTION
Accounting related functions, such as invoicing, should not be shown if the Admin has opted to disable the accounting module.
This was already hidden in the main tickets.php view, it was just still showing on client_tickets.php

https://forum.itflow.org/d/708-client-ticket-billable-collumm