### PR TITLE
Ticket States

### DIFF
--- a/calendar_events.php
+++ b/calendar_events.php
@@ -161,15 +161,14 @@ while ($row = mysqli_fetch_array($sql)) {
                 $event_title = json_encode($row['ticket_prefix'] . $row['ticket_number'] . " created - " . $row['ticket_subject'] . " " . $username . "{" . $ticket_status . "}");
                 $event_start = json_encode($row['ticket_created_at']);
 
-
-                if ($ticket_status == "Closed") {
-                    $event_color = "black";
-                } else if ($ticket_status == "Scheduled") {
-                    $event_color = "grey";
-                } else if ($ticket_status == "Pending-Assignment") {
+                if ($ticket_status == "New") {
                     $event_color = "red";
-                } else {
+                } else if ($ticket_status == "Open") {
                     $event_color = "blue";
+                }  else if ($ticket_status == "On Hold") {
+                    $event_color = "grey";
+                } else {
+                    $event_color = "black";
                 }
 
                 echo "{ id: $event_id, title: $event_title, start: $event_start, color: '$event_color', url: 'ticket.php?ticket_id=$event_id' },";
@@ -188,7 +187,7 @@ while ($row = mysqli_fetch_array($sql)) {
                 }
 
                 if (strtotime($row['ticket_schedule']) < time()) {
-                    if ($row['ticket_status'] == 'Scheduled') {
+                    if ($row['ticket_status'] == 'On Hold') {
                         $event_color = "red";
                     } else {
                         $event_color = "green";
@@ -200,7 +199,7 @@ while ($row = mysqli_fetch_array($sql)) {
                 $ticket_status = strval($row['ticket_status']);
                 $event_title = json_encode($row['ticket_prefix'] . $row['ticket_number'] . " scheduled - " . $row['ticket_subject'] . " [" . $username . "]{" . $ticket_status . "}");
                 $event_start = json_encode($row['ticket_schedule']);
-                
+
 
                 echo "{ id: $event_id, title: $event_title, start: $event_start, color: '$event_color', url: 'ticket.php?ticket_id=$event_id' },";
             }

--- a/calendar_events.php
+++ b/calendar_events.php
@@ -163,9 +163,9 @@ while ($row = mysqli_fetch_array($sql)) {
 
                 if ($ticket_status == "New") {
                     $event_color = "red";
-                } else if ($ticket_status == "Open") {
+                } elseif ($ticket_status == "Open") {
                     $event_color = "blue";
-                }  else if ($ticket_status == "On Hold") {
+                }  elseif ($ticket_status == "On Hold") {
                     $event_color = "grey";
                 } else {
                     $event_color = "black";

--- a/client_events.php
+++ b/client_events.php
@@ -163,9 +163,9 @@ while ($row = mysqli_fetch_array($sql)) {
 
                     if ($ticket_status == "New") {
                         $event_color = "red";
-                    } else if ($ticket_status == "Open") {
+                    } elseif ($ticket_status == "Open") {
                         $event_color = "blue";
-                    }  else if ($ticket_status == "On Hold") {
+                    }  elseif ($ticket_status == "On Hold") {
                         $event_color = "grey";
                     } else {
                         $event_color = "black";

--- a/client_events.php
+++ b/client_events.php
@@ -161,15 +161,14 @@ while ($row = mysqli_fetch_array($sql)) {
                     $event_title = json_encode($row['ticket_prefix'] . $row['ticket_number'] . " created - " . $row['ticket_subject'] . " " . $username . "{" . $ticket_status . "}");
                     $event_start = json_encode($row['ticket_created_at']);
 
-
-                    if ($ticket_status == "Closed") {
-                        $event_color = "black";
-                    } else if ($ticket_status == "Scheduled") {
-                        $event_color = "grey";
-                    } else if ($ticket_status == "Pending-Assignment") {
+                    if ($ticket_status == "New") {
                         $event_color = "red";
-                    } else {
+                    } else if ($ticket_status == "Open") {
                         $event_color = "blue";
+                    }  else if ($ticket_status == "On Hold") {
+                        $event_color = "grey";
+                    } else {
+                        $event_color = "black";
                     }
 
                     echo "{ id: $event_id, title: $event_title, start: $event_start, color: '$event_color', url: 'ticket.php?ticket_id=$event_id' },";
@@ -200,7 +199,7 @@ while ($row = mysqli_fetch_array($sql)) {
                     $ticket_status = strval($row['ticket_status']);
                     $event_title = json_encode($row['ticket_prefix'] . $row['ticket_number'] . " scheduled - " . $row['ticket_subject'] . " [" . $username . "]{" . $ticket_status . "}");
                     $event_start = json_encode($row['ticket_schedule']);
-                    
+
 
                     echo "{ id: $event_id, title: $event_title, start: $event_start, color: '$event_color', url: 'ticket.php?ticket_id=$event_id' },";
                 }

--- a/client_tickets.php
+++ b/client_tickets.php
@@ -160,16 +160,16 @@ $total_scheduled_tickets = intval($row['total_scheduled_tickets']);
                     }
                     $ticket_closed_at = nullable_htmlentities($row['ticket_closed_at']);
 
-                    if ($ticket_status == "Pending-Assignment") {
+                    if ($ticket_status == "New") {
                         $ticket_status_color = "danger";
-                    } elseif ($ticket_status == "Assigned") {
+                    } elseif ($ticket_status == "Open") {
                         $ticket_status_color = "primary";
-                    } elseif ($ticket_status == "In-Progress") {
+                    } elseif ($ticket_status == "On Hold") {
                         $ticket_status_color = "success";
+                    } elseif ($ticket_status == "Auto Close") {
+                        $ticket_status_color = "dark";
                     } elseif ($ticket_status == "Closed") {
                         $ticket_status_color = "dark";
-                    } else{
-                        $ticket_status_color = "secondary";
                     }
 
                     if ($ticket_priority == "High") {
@@ -181,6 +181,7 @@ $total_scheduled_tickets = intval($row['total_scheduled_tickets']);
                     } else{
                         $ticket_priority_display = "-";
                     }
+
                     $ticket_assigned_to = intval($row['ticket_assigned_to']);
                     if (empty($ticket_assigned_to)) {
                         if ($ticket_status == "Closed") {

--- a/cron.php
+++ b/cron.php
@@ -219,20 +219,20 @@ foreach ($warranty_alert_array as $day) {
 // Logging
 //mysqli_query($mysqli, "INSERT INTO logs SET log_type = 'Cron', log_action = 'Task', log_description = 'Cron created notifications for asset warranties expiring'");
 
-// Notify of Tickets Pending Assignment
+// Notify of New Tickets
 // Get Ticket Pending Assignment
 $sql_tickets_pending_assignment = mysqli_query($mysqli,"SELECT ticket_id FROM tickets
-    WHERE ticket_status = 'Pending-Assignment'"
+    WHERE ticket_status = 'New'"
 );
 
 $tickets_pending_assignment = mysqli_num_rows($sql_tickets_pending_assignment);
 
 if($tickets_pending_assignment > 0){
 
-    mysqli_query($mysqli, "INSERT INTO notifications SET notification_type = 'Pending Tickets', notification = 'There are $tickets_pending_assignment Tickets pending assignment', notification_action = 'tickets.php?status=Pending-Assignment'");
+    mysqli_query($mysqli, "INSERT INTO notifications SET notification_type = 'Pending Tickets', notification = 'There are $tickets_pending_assignment new tickets pending assignment', notification_action = 'tickets.php?status=New'");
 
     // Logging
-    mysqli_query($mysqli, "INSERT INTO logs SET log_type = 'Cron', log_action = 'Task', log_description = 'Cron created notifications for tickets that are pending assignment'");
+    mysqli_query($mysqli, "INSERT INTO logs SET log_type = 'Cron', log_action = 'Task', log_description = 'Cron created notifications for new tickets that are pending assignment'");
 }
 
 // Recurring (Scheduled) tickets
@@ -262,7 +262,7 @@ if (mysqli_num_rows($sql_scheduled_tickets) > 0) {
         mysqli_query($mysqli, "UPDATE settings SET config_ticket_next_number = $new_config_ticket_next_number WHERE company_id = 1");
 
         // Raise the ticket
-        mysqli_query($mysqli, "INSERT INTO tickets SET ticket_prefix = '$config_ticket_prefix', ticket_number = $ticket_number, ticket_subject = '$subject', ticket_details = '$details', ticket_priority = '$priority', ticket_status = 'Open', ticket_created_by = $created_id, ticket_contact_id = $contact_id, ticket_client_id = $client_id, ticket_asset_id = $asset_id");
+        mysqli_query($mysqli, "INSERT INTO tickets SET ticket_prefix = '$config_ticket_prefix', ticket_number = $ticket_number, ticket_subject = '$subject', ticket_details = '$details', ticket_priority = '$priority', ticket_status = 'New', ticket_created_by = $created_id, ticket_contact_id = $contact_id, ticket_client_id = $client_id, ticket_asset_id = $asset_id");
         $id = mysqli_insert_id($mysqli);
 
         // Logging
@@ -366,7 +366,7 @@ if (mysqli_num_rows($sql_scheduled_tickets) > 0) {
 // AUTO CLOSE TICKET - CLOSE
 //  Automatically silently closes tickets 22 hrs after the last chase
 
-// Check to make sure autoclose is enabled
+// Check to make sure auto-close is enabled
 if ($config_ticket_autoclose == 1) {
     $sql_tickets_to_chase = mysqli_query(
         $mysqli,
@@ -420,7 +420,7 @@ if ($config_ticket_autoclose == 1) {
         $ticket_reply = $ticket_reply_row['ticket_reply'];
 
         $subject = "Ticket pending closure - [$ticket_prefix$ticket_number] - $ticket_subject";
-        $body = "<i style=\'color: #808080\'>##- Please type your reply above this line -##</i><br><br>Hello, $contact_name<br><br>This is an automatic friendly reminder that your ticket regarding $ticket_subject will be closed, unless you respond.<br><br>--------------------------------<br>$ticket_reply--------------------------------<br><br>If your issue is resolved, you can ignore this email - the ticket will automatically close. If you need further assistance, please respond to this email.  <br><br>Ticket: $ticket_prefix$ticket_number<br>Subject: $ticket_subject<br>Status: $ticket_status<br>Portal: https://$config_base_url/portal/ticket.php?id=$ticket_id<br><br>--<br>$company_name - Support<br>$config_ticket_from_email<br>$company_phone";
+        $body = "<i style=\'color: #808080\'>##- Please type your reply above this line -##</i><br><br>Hello, $contact_name<br><br>This is an automatic friendly reminder that your ticket regarding $ticket_subject will be closed, unless you respond.<br><br>--------------------------------<br>$ticket_reply--------------------------------<br><br>If your issue is resolved, you can ignore this email - the ticket will automatically close shortly. If you need further assistance, please respond to this email.  <br><br>Ticket: $ticket_prefix$ticket_number<br>Subject: $ticket_subject<br>Status: $ticket_status<br>Portal: https://$config_base_url/portal/ticket.php?id=$ticket_id<br><br>--<br>$company_name - Support<br>$config_ticket_from_email<br>$company_phone";
 
         $data = [
             [

--- a/dashboard.php
+++ b/dashboard.php
@@ -795,16 +795,17 @@ if ($user_config_dashboard_technical_enable == 1) {
                                     $client_name = nullable_htmlentities($row['client_name']);
                                     $contact_id = intval($row['ticket_contact_id']);
                                     $contact_name = nullable_htmlentities($row['contact_name']);
-                                    if ($ticket_status == "Pending-Assignment") {
+
+                                    if ($ticket_status == "New") {
                                         $ticket_status_color = "danger";
-                                    } elseif ($ticket_status == "Assigned") {
+                                    } elseif ($ticket_status == "Open") {
                                         $ticket_status_color = "primary";
-                                    } elseif ($ticket_status == "In-Progress") {
+                                    } elseif ($ticket_status == "On Hold") {
                                         $ticket_status_color = "success";
+                                    } elseif ($ticket_status == "Auto Close") {
+                                        $ticket_status_color = "dark";
                                     } elseif ($ticket_status == "Closed") {
                                         $ticket_status_color = "dark";
-                                    } else {
-                                        $ticket_status_color = "secondary";
                                     }
 
                                     if ($ticket_priority == "High") {

--- a/functions.php
+++ b/functions.php
@@ -727,7 +727,7 @@ function sanitizeInput($input)
     global $mysqli;
 
     // Remove HTML and PHP tags
-    $input = strip_tags($input);
+    $input = strip_tags((string) $input);
 
     // Remove white space from beginning and end of input
     $input = trim($input);
@@ -1029,7 +1029,11 @@ function addToMailQueue($mysqli, $data)
         $recipient_name = strval($email['recipient_name']);
         $subject = strval($email['subject']);
         $body = strval($email['body']);
-        $cal_str = mysqli_escape_string($mysqli,$email['cal_str']);
+
+        $cal_str = '';
+        if (isset($email['cal_str'])) {
+            $cal_str = mysqli_escape_string($mysqli,$email['cal_str']);
+        }
 
         // Check if 'email_queued_at' is set and not empty
         if (isset($email['queued_at']) && !empty($email['queued_at'])) {
@@ -1110,7 +1114,7 @@ function createiCalStrCancel($originaliCalStr) {
 
     // Import the original iCal string
     $cal_event = new ZCiCal($originaliCalStr);
-    
+
     // Iterate through the iCalendar object to find VEVENT nodes
     foreach($cal_event->tree->child as $node) {
         if($node->getName() == "VEVENT") {
@@ -1133,4 +1137,4 @@ function createiCalStrCancel($originaliCalStr) {
     // Return the modified iCal string
     return $cal_event->export();
 }
-    
+

--- a/get_settings.php
+++ b/get_settings.php
@@ -238,17 +238,10 @@ $asset_status_array = array (
 );
 
 $ticket_status_array = array (
-    'Pending-Assignment',
-    'Assigned',
-    'Client-Replied',
-    'In-Progress',
-    'Pending-Shipment',
-    'Pending-Client',
-    'Pending-Vendor',
-    'Scheduled',
-    'Closed',
     'Open',
-    'Auto Close'
+    'On Hold',
+    'Auto Close',
+    'Closed'
 );
 
 $industry_select_array = array(

--- a/portal/portal_post.php
+++ b/portal/portal_post.php
@@ -33,7 +33,7 @@ if (isset($_POST['add_ticket'])) {
     $new_config_ticket_next_number = $config_ticket_next_number + 1;
     mysqli_query($mysqli, "UPDATE settings SET config_ticket_next_number = $new_config_ticket_next_number WHERE company_id = 1");
 
-    mysqli_query($mysqli, "INSERT INTO tickets SET ticket_prefix = '$config_ticket_prefix', ticket_number = $ticket_number, ticket_subject = '$subject', ticket_details = '$details', ticket_priority = '$priority', ticket_status = 'Open', ticket_created_by = 0, ticket_contact_id = $contact, ticket_client_id = $client_id");
+    mysqli_query($mysqli, "INSERT INTO tickets SET ticket_prefix = '$config_ticket_prefix', ticket_number = $ticket_number, ticket_subject = '$subject', ticket_details = '$details', ticket_priority = '$priority', ticket_status = 'New', ticket_created_by = 0, ticket_contact_id = $contact, ticket_client_id = $client_id");
     $id = mysqli_insert_id($mysqli);
 
     // Notify agent DL of the new ticket, if populated with a valid email
@@ -87,6 +87,40 @@ if (isset($_POST['add_ticket_comment'])) {
 
         // Update Ticket Last Response Field & set ticket to open as client has replied
         mysqli_query($mysqli, "UPDATE tickets SET ticket_status = 'Open' WHERE ticket_id = $ticket_id AND ticket_client_id = $session_client_id LIMIT 1");
+
+
+        // Get ticket details &  Notify the assigned tech (if any)
+        $ticket_details = mysqli_fetch_array(mysqli_query($mysqli, "SELECT * FROM tickets LEFT JOIN clients ON ticket_client_id = client_id WHERE ticket_id = $ticket_id LIMIT 1"));
+
+        $ticket_number = intval($ticket_details['ticket_number']);
+        $ticket_assigned_to = intval($ticket_details['ticket_assigned_to']);
+        $ticket_subject = sanitizeInput($ticket_details['ticket_subject']);
+        $client_name = sanitizeInput($ticket_details['client_name']);
+
+        if ($ticket_details && $ticket_assigned_to !== 0) {
+
+            // Get tech details
+            $tech_details = mysqli_fetch_array(mysqli_query($mysqli, "SELECT user_email, user_name FROM users WHERE user_id = $ticket_assigned_to LIMIT 1"));
+            $tech_email = sanitizeInput($tech_details['user_email']);
+            $tech_name = sanitizeInput($tech_details['user_name']);
+
+            $subject = "$config_app_name Ticket updated - [$config_ticket_prefix$ticket_number] $ticket_subject";
+            $body    = "Hello $tech_name,<br><br>A new reply has been added to the below ticket, check ITFlow for full details.<br><br>Client: $client_name<br>Ticket: $config_ticket_prefix$ticket_number<br>Subject: $ticket_subject<br><br>https://$config_base_url/ticket.php?ticket_id=$ticket_id";
+
+            $data = [
+                [
+                    'from' => $config_ticket_from_email,
+                    'from_name' => $config_ticket_from_name,
+                    'recipient' => $tech_email,
+                    'recipient_name' => $tech_name,
+                    'subject' => $subject,
+                    'body' => $body
+                ]
+            ];
+
+            addToMailQueue($mysqli, $data);
+
+        }
 
         // Store any attached any files
         if (!empty($_FILES)) {

--- a/ticket.php
+++ b/ticket.php
@@ -59,7 +59,7 @@ if (isset($_GET['ticket_id'])) {
         $ticket_scheduled_for = nullable_htmlentities($row['ticket_schedule']);
         $ticket_onsite = nullable_htmlentities($row['ticket_onsite']);
 
-        //Set Ticket Bage Color based of priority
+        //Set Ticket Badge Color based of priority
         if ($ticket_priority == "High") {
             $ticket_priority_display = "<span class='p-2 badge badge-danger'>$ticket_priority</span>";
         } elseif ($ticket_priority == "Medium") {
@@ -72,16 +72,16 @@ if (isset($_GET['ticket_id'])) {
         $ticket_feedback = nullable_htmlentities($row['ticket_feedback']);
 
         $ticket_status = nullable_htmlentities($row['ticket_status']);
-        if ($ticket_status == "Pending-Assignment") {
+        if ($ticket_status == "New") {
             $ticket_status_display = "<span class='p-2 badge badge-danger'>$ticket_status</span>";
-        } elseif ($ticket_status == "Assigned") {
+        } elseif ($ticket_status == "Open") {
             $ticket_status_display = "<span class='p-2 badge badge-primary'>$ticket_status</span>";
-        } elseif ($ticket_status == "In-Progress") {
+        } elseif ($ticket_status == "On Hold") {
             $ticket_status_display = "<span class='p-2 badge badge-success'>$ticket_status</span>";
-        } elseif ($ticket_status == "Closed") {
+        } elseif ($ticket_status == "Auto Close" || $ticket_status == "Closed") {
             $ticket_status_display = "<span class='p-2 badge badge-dark'>$ticket_status</span>";
         } else {
-            $ticket_status_display = "<span class='p-2 badge badge-secondary'>$ticket_status</span>";
+            $ticket_status_display = "<span class='p-2 badge badge-secondary'>$ticket_status</span>"; // To be removed
         }
 
         $ticket_vendor_ticket_number = nullable_htmlentities($row['ticket_vendor_ticket_number']);
@@ -276,7 +276,7 @@ if (isset($_GET['ticket_id'])) {
 
         <div class="row">
 
-            
+
             <div class="col-md-9">
                 <div class="card card-body">
                     <div class="card card-outline card-primary mb-3">
@@ -328,18 +328,12 @@ if (isset($_GET['ticket_id'])) {
                                             <span class="input-group-text"><i class="fa fa-fw fa-thermometer-half"></i></span>
                                         </div>
                                         <select class="form-control select2" name="status" required>
-                                            <option <?php if ($ticket_status == "In-Progress") {
+                                            <option <?php if ($ticket_status == "Open") {
                                                         echo "selected";
-                                                    } ?>>In-Progress</option>
-                                            <option <?php if ($ticket_status == "Pending-Client") {
+                                                    } ?>>Open</option>
+                                            <option <?php if ($ticket_status == "On Hold") {
                                                         echo "selected";
-                                                    } ?>>Pending-Client</option>
-                                            <option <?php if ($ticket_status == "Pending-Vendor") {
-                                                        echo "selected";
-                                                    } ?>>Pending-Vendor</option>
-                                            <option <?php if ($ticket_status == "Pending-Shipment") {
-                                                        echo "selected";
-                                                    } ?>>Pending-Shipment</option>
+                                                    } ?>>On Hold</option>
                                             <?php if ($config_ticket_autoclose) { ?>
                                                 <option <?php if ($ticket_status == 'Auto Close') {
                                                             echo "selected";
@@ -383,7 +377,7 @@ if (isset($_GET['ticket_id'])) {
                                 </div>
 
 
-                            
+
                                 <?php
                                 // Set the initial ticket response type (private/internal note)
                                 //  Future updates of the wording/icon are done by Javascript
@@ -540,7 +534,7 @@ if (isset($_GET['ticket_id'])) {
 
                 </div>
             </div>
-       
+
             <div class="col-md-3">
                 <div class="card card-body">
 

--- a/ticket_bulk_close_modal.php
+++ b/ticket_bulk_close_modal.php
@@ -18,8 +18,8 @@
                 <div class="form-group">
                     <div class="custom-control custom-checkbox">
                         <input type="checkbox" class="custom-control-input" id="bulkPrivateCheckbox" name="bulk_private_note" value="1">
-                        <label class="custom-control-label" for="bulkPrivateCheckbox">Mark as a Private</label>
-                        <small class="form-text text-muted">If checked the contact and any watcher will not be informed</small>
+                        <label class="custom-control-label" for="bulkPrivateCheckbox">Mark as Internal</label>
+                        <small class="form-text text-muted">If checked this note will only be visible to agents. The contact / watcher will not be informed this ticket was closed.</small>
                     </div>
                 </div>
 

--- a/ticket_bulk_reply_modal.php
+++ b/ticket_bulk_reply_modal.php
@@ -2,7 +2,7 @@
     <div class="modal-dialog modal-lg">
         <div class="modal-content bg-dark">
             <div class="modal-header">
-                <h5 class="modal-title"><i class="fas fa-fw fa-paper-plane mr-2"></i>Bulk Reply</h5>
+                <h5 class="modal-title"><i class="fas fa-fw fa-paper-plane mr-2"></i>Bulk Update/Reply</h5>
                 <button type="button" class="close text-white" data-dismiss="modal">
                     <span>&times;</span>
                 </button>
@@ -16,11 +16,8 @@
                         <span class="input-group-text"><i class="fa fa-fw fa-thermometer-half"></i></span>
                     </div>
                     <select class="form-control select2" name="bulk_status">
-                        <option>In-Progress</option>
-                        <option>Pending-Client</option>
-                        <option>Pending-Vendor</option>
-                        <option>Pending-Shipment</option>
-                        <option>Scheduled</option>
+                        <option>Open</option>
+                        <option>On Hold</option>
                     </select>
                 </div>
 
@@ -31,8 +28,8 @@
                 <div class="form-group">
                     <div class="custom-control custom-checkbox">
                         <input type="checkbox" class="custom-control-input" id="bulkPrivateReplyCheckbox" name="bulk_private_reply" value="1">
-                        <label class="custom-control-label" for="bulkPrivateReplyCheckbox">Mark as a Private</label>
-                        <small class="form-text text-muted">If checked the contact and any watcher will not be informed</small>
+                        <label class="custom-control-label" for="bulkPrivateReplyCheckbox">Mark as internal</label>
+                        <small class="form-text text-muted">If checked this note will only be visible to agents.</small>
                     </div>
                 </div>
 

--- a/tickets.php
+++ b/tickets.php
@@ -163,7 +163,7 @@ $user_active_assigned_tickets = intval($row['total_tickets_assigned']);
                                 </a>
                                 <div class="dropdown-divider"></div>
                                 <a class="dropdown-item" href="#" data-toggle="modal" data-target="#bulkReplyTicketModal">
-                                    <i class="fas fa-fw fa-paper-plane mr-2"></i>Bulk Reply
+                                    <i class="fas fa-fw fa-paper-plane mr-2"></i>Bulk Update/Reply
                                 </a>
                             </div>
                         </div>
@@ -236,24 +236,18 @@ $user_active_assigned_tickets = intval($row['total_tickets_assigned']);
                         <div class="form-group">
                             <label>Ticket Status</label>
                             <select class="form-control select2" name="status[]" data-placeholder="Select Status" multiple>
-                                <option value="In-Progress" <?php if (isset($_GET['status']) && is_array($_GET['status']) && in_array('In-Progress', $_GET['status'])) {
+                                <option value="New" <?php if (isset($_GET['status']) && is_array($_GET['status']) && in_array('New', $_GET['status'])) {
                                                                 echo 'selected';
-                                                            } ?>>In-Progress</option>
-                                <option value="Client-Replied" <?php if (isset($_GET['status']) && is_array($_GET['status']) && in_array('Client-Replied', $_GET['status'])) {
+                                                            } ?>>New</option>
+                                <option value="Open" <?php if (isset($_GET['status']) && is_array($_GET['status']) && in_array('Open', $_GET['status'])) {
                                                                     echo 'selected';
-                                                                } ?>>Client-Replied</option>
-                                <option value="Pending-Client" <?php if (isset($_GET['status']) && is_array($_GET['status']) && in_array('Pending-Client', $_GET['status'])) {
+                                                                } ?>>Open</option>
+                                <option value="On Hold" <?php if (isset($_GET['status']) && is_array($_GET['status']) && in_array('On Hold', $_GET['status'])) {
                                                                     echo 'selected';
-                                                                } ?>>Pending-Client</option>
-                                <option value="Pending-Vendor" <?php if (isset($_GET['status']) && is_array($_GET['status']) && in_array('Pending-Vendor', $_GET['status'])) {
+                                                                } ?>>On Hold</option>
+                                <option value="Auto Close" <?php if (isset($_GET['status']) && is_array($_GET['status']) && in_array('Auto Close', $_GET['status'])) {
                                                                     echo 'selected';
-                                                                } ?>>Pending-Vendor</option>
-                                <option value="Pending-Shipment" <?php if (isset($_GET['status']) && is_array($_GET['status']) && in_array('Pending-Shipment', $_GET['status'])) {
-                                                                        echo 'selected';
-                                                                    } ?>>Pending-Shipment</option>
-                                <option value="Scheduled" <?php if (isset($_GET['status']) && is_array($_GET['status']) && in_array('Scheduled', $_GET['status'])) {
-                                                                echo 'selected';
-                                                            } ?>>Scheduled</option>
+                                                                } ?>>Auto Close</option>
                                 <option value="Closed" <?php if (isset($_GET['status']) && is_array($_GET['status']) && in_array('Closed', $_GET['status'])) {
                                                             echo 'selected';
                                                         } ?>>Closed</option>
@@ -338,6 +332,7 @@ $user_active_assigned_tickets = intval($row['total_tickets_assigned']);
                             $ticket_priority = nullable_htmlentities($row['ticket_priority']);
                             $ticket_status = nullable_htmlentities($row['ticket_status']);
                             $ticket_billable = intval($row['ticket_billable']);
+                            $ticket_scheduled_for = nullable_htmlentities($row['ticket_schedule']);
                             $ticket_vendor_ticket_number = nullable_htmlentities($row['ticket_vendor_ticket_number']);
                             $ticket_created_at = nullable_htmlentities($row['ticket_created_at']);
                             $ticket_created_at_time_ago = timeAgo($row['ticket_created_at']);
@@ -362,20 +357,17 @@ $user_active_assigned_tickets = intval($row['total_tickets_assigned']);
                             $contact_phone = formatPhoneNumber($row['contact_phone']);
                             $contact_extension = nullable_htmlentities($row['contact_extension']);
                             $contact_mobile = formatPhoneNumber($row['contact_mobile']);
-                            if ($ticket_status == "Pending-Assignment") {
+
+                            if ($ticket_status == "New") {
                                 $ticket_status_color = "danger";
-                            } elseif ($ticket_status == "Assigned") {
+                            } elseif ($ticket_status == "Open") {
                                 $ticket_status_color = "primary";
-                            } elseif ($ticket_status == "In-Progress") {
+                            } elseif ($ticket_status == "On Hold") {
                                 $ticket_status_color = "success";
-                            } elseif ($ticket_status == "Closed") {
-                                $ticket_status_color = "dark";
                             } elseif ($ticket_status == "Auto Close") {
                                 $ticket_status_color = "dark";
-                            } elseif ($ticket_status == "Client-Replied") {
-                                $ticket_status_color = "warning";
-                            } else {
-                                $ticket_status_color = "secondary";
+                            } elseif ($ticket_status == "Closed") {
+                                $ticket_status_color = "dark";
                             }
 
                             if ($ticket_priority == "High") {
@@ -385,6 +377,7 @@ $user_active_assigned_tickets = intval($row['total_tickets_assigned']);
                             } else {
                                 $ticket_priority_color = "info";
                             }
+
                             $ticket_assigned_to = intval($row['ticket_assigned_to']);
                             if (empty($ticket_assigned_to)) {
                                 if ($ticket_status == "Closed") {
@@ -430,8 +423,8 @@ $user_active_assigned_tickets = intval($row['total_tickets_assigned']);
 
                                     <div class="mt-1"><?php echo $contact_display; ?></div>
                                 </td>
-                                <?php if ($config_module_enable_accounting) {
-                                ?>
+
+                                <?php if ($config_module_enable_accounting) { ?>
                                     <td class="text-center">
                                         <a href="#" data-toggle="modal" data-target="#editTicketBillableModal<?php echo $ticket_id; ?>">
                                             <?php
@@ -442,11 +435,10 @@ $user_active_assigned_tickets = intval($row['total_tickets_assigned']);
                                             }
                                             ?>
                                     </td>
-                                <?php
-                                }
-                                ?>
+                                <?php } ?>
+
                                 <td><a href="#" data-toggle="modal" data-target="#editTicketPriorityModal<?php echo $ticket_id; ?>"><span class='p-2 badge badge-pill badge-<?php echo $ticket_priority_color; ?>'><?php echo $ticket_priority; ?></span></a></td>
-                                <td><span class='p-2 badge badge-pill badge-<?php echo $ticket_status_color; ?>'><?php echo $ticket_status; ?></span></td>
+                                <td><span class='p-2 badge badge-pill badge-<?php echo $ticket_status_color; ?>'><?php echo $ticket_status; ?></span> <?php if ($ticket_status == 'On Hold' && isset ($ticket_scheduled_for)) { echo "<div class=\"mt-1\"> <small class='text-secondary'> $ticket_scheduled_for </small></div>"; } ?></td>
                                 <td><a href="#" data-toggle="modal" data-target="#assignTicketModal<?php echo $ticket_id; ?>"><?php echo $ticket_assigned_to_display; ?></a></td>
                                 <td><?php echo $ticket_updated_at_display; ?></td>
                                 <td>


### PR DESCRIPTION
@johnnyq As discussed, this PR will standardize on 5 consistent ticket states:-
- New: A new, unassigned, ticket that requires attention _(Red/Danger)_
- Open: An open ticket that is being worked on, either because it has just been assigned or replied to by the client _(Blue/Primary)_
- On Hold: A ticket that is pending an action (e.g. a client reply, future scheduled work, awaiting third party, awaiting parts, etc.) _(Green/Success)_
- Auto Close: To be used when you believe a request is resolved; automatically chases the contact to check and then closes (if auto-closing tickets are enabled) _(Dark/black)_
- Closed: Closed tickets are for completed requests/issues, they cannot be re-opened _(Dark/black)_

Some parts of the app have inconsistently deviated from these states (e.g. just for email parsing) and have therefore been reverted. Other states may be configurable in future via custom fields.

Additionally: 
- Added agent notifications when users update tickets on the portal
- Adjusted some email wording for consistency & corrected URLs