### PR TITLE
Add removal notices for Stripe Fees & 'open ticket' time tracker

### DIFF
--- a/settings_online_payment.php
+++ b/settings_online_payment.php
@@ -66,6 +66,12 @@ require_once "inc_all_settings.php";
                     </div>
                 </div>
 
+                <hr>
+
+                <div class="alert alert-danger" role="alert">
+                    "Client Pays Fees" / The ability to pass Stripe fees onto clients will be removed in a future version of ITFlow.
+                </div>
+
                 <div class="form-group">
                     <label>Percentage Fee</label>
                     <div class="input-group">

--- a/top_nav_tickets_modal.php
+++ b/top_nav_tickets_modal.php
@@ -9,6 +9,11 @@
                 </button>
             </div>
             <div class="modal-body">
+
+                <div class="alert alert-danger" role="alert">
+                    This "Open Tickets" tracker will be removed in a future version of IFlow. Time tracking will still be a feature.
+                </div>
+
                 <div id="openTicketsContainer">
                     <!-- Open tickets will be loaded here via JavaScript -->
                 </div>

--- a/top_nav_tickets_modal.php
+++ b/top_nav_tickets_modal.php
@@ -11,7 +11,7 @@
             <div class="modal-body">
 
                 <div class="alert alert-danger" role="alert">
-                    This "Open Tickets" tracker will be removed in a future version of IFlow. Time tracking will still be a feature.
+                    This "Open Tickets" tracker will be removed in a future version of ITFlow. Time tracking will still be a feature.
                 </div>
 
                 <div id="openTicketsContainer">


### PR DESCRIPTION
Add removal notices to the "Client Pays Fees" and "Open tickets" tracker.

![image](https://github.com/itflow-org/itflow/assets/32306651/5402bb7a-e6a5-4b93-b893-a6173bb10787)


![image](https://github.com/itflow-org/itflow/assets/32306651/24fc326f-689c-4f0a-900e-d872057812a0)
