### PR TITLE
Set 2FA Remember-me cookie expiry

### DIFF
--- a/login.php
+++ b/login.php
@@ -159,7 +159,7 @@ if (isset($_POST['login'])) {
             if (isset($_POST['remember_me'])) {
                 // TODO: Record the UA and IP a token is generated from so that can be shown later on
                 $newRememberToken = bin2hex(random_bytes(64));
-                setcookie('rememberme', $newRememberToken, time() + 86400*2, "/", null, true, true);
+                setcookie('rememberme', $newRememberToken, time() + 86400*$config_login_remember_me_expire, "/", null, true, true);
                 mysqli_query($mysqli, "INSERT INTO remember_tokens SET remember_token_user_id = $user_id, remember_token_token = '$newRememberToken'");
 
                 $extended_log .= ", generated a new remember-me token";


### PR DESCRIPTION
Currently, the token is only valid for 2 days (86400 seconds = 24 hrs, multiplied by 2). 

This PR adjusts the cookie expiry date to the number of days configured that tokens are cleared after. This should help ensure users are not prompted for 2FA every few days, even if they've set a longer interval.