### PR TITLE
2FA tweaks

### DIFF
--- a/login.php
+++ b/login.php
@@ -230,7 +230,7 @@ if (isset($_POST['login'])) {
             // HTML code for the token input field
             $token_field = "
                     <div class='input-group mb-3'>
-                        <input type='text' inputmode='numeric' pattern='[0-9]*' class='form-control' placeholder='Enter your 2FA code' name='current_code' required autofocus>
+                        <input type='text' inputmode='numeric' pattern='[0-9]*' maxlength='6' class='form-control' placeholder='Enter your 2FA code' name='current_code' required autofocus>
                         <div class='input-group-append'>
                           <div class='input-group-text'>
                             <span class='fas fa-key'></span>

--- a/post/profile.php
+++ b/post/profile.php
@@ -208,6 +208,9 @@ if(isset($_POST['enable_2fa'])){
 
     mysqli_query($mysqli,"UPDATE users SET user_token = '$token' WHERE user_id = $session_user_id");
 
+    // Delete any existing 2FA tokens - these browsers should be re-validated
+    mysqli_query($mysqli, "DELETE FROM remember_tokens WHERE remember_token_user_id = $session_user_id");
+
     //Logging
     mysqli_query($mysqli,"INSERT INTO logs SET log_type = 'User Settings', log_action = 'Modify', log_description = '$session_name enabled 2FA on their account', log_ip = '$session_ip', log_user_agent = '$session_user_agent', log_user_id = $session_user_id");
 


### PR DESCRIPTION
- Set the 2FA number input field to only accept 6 characters max
- Revoke existing remember-me tokens when 2FA is re-enabled