### PR TITLE
Add audit log cleanup/retention period to cron

### DIFF
--- a/cron.php
+++ b/cron.php
@@ -67,8 +67,11 @@ $config_telemetry = intval($row['config_telemetry']);
 $config_enable_alert_domain_expire = intval($row['config_enable_alert_domain_expire']);
 $config_send_invoice_reminders = intval($row['config_send_invoice_reminders']);
 
-// Remmeber Token Expire
+// Remember-me Token Expiry
 $config_login_remember_me_expire = intval($row['config_login_remember_me_expire']);
+
+// Log retention
+$config_log_retention = intval($row['config_log_retention']);
 
 // Set Currency Format
 $currency_format = numfmt_create($company_locale, NumberFormatter::CURRENCY);
@@ -120,8 +123,11 @@ mysqli_query($mysqli, "DELETE FROM notifications WHERE notification_dismissed_at
 // Clean-up mail queue
 mysqli_query($mysqli, "DELETE FROM email_queue WHERE email_queued_at < CURDATE() - INTERVAL 90 DAY");
 
-// Clean-up old remember me tokens (2 or more days old)
+// Clean-up old remember me tokens
 mysqli_query($mysqli, "DELETE FROM remember_tokens WHERE remember_token_created_at < CURDATE() - INTERVAL $config_login_remember_me_expire DAY");
+
+// Cleanup old audit logs
+mysqli_query($mysqli, "DELETE FROM logs WHERE log_created_at < CURDATE() - INTERVAL $config_log_retention DAY");
 
 //Logging
 //mysqli_query($mysqli, "INSERT INTO logs SET log_type = 'Cron', log_action = 'Task', log_description = 'Cron cleaned up old data'");

--- a/database_updates.php
+++ b/database_updates.php
@@ -1944,7 +1944,7 @@ if (LATEST_DATABASE_VERSION > CURRENT_DATABASE_VERSION) {
 
     if (CURRENT_DATABASE_VERSION == '1.3.6') {
         mysqli_query($mysqli, "ALTER TABLE `clients` ADD `client_abbreviation` VARCHAR(10) DEFAULT NULL AFTER `client_tax_id_number`");
-    
+
         mysqli_query($mysqli, "UPDATE `settings` SET `config_current_database_version` = '1.3.7'");
      }
 
@@ -1975,7 +1975,7 @@ if (LATEST_DATABASE_VERSION > CURRENT_DATABASE_VERSION) {
         )");
 
         mysqli_query($mysqli, "UPDATE `settings` SET `config_current_database_version` = '1.3.9'");
-    
+
     }
 
     if (CURRENT_DATABASE_VERSION == '1.3.9') {
@@ -2073,14 +2073,21 @@ if (LATEST_DATABASE_VERSION > CURRENT_DATABASE_VERSION) {
         mysqli_query($mysqli, "ALTER TABLE `assets` ADD `asset_photo` VARCHAR(200) DEFAULT NULL AFTER `asset_install_date`");
 
         mysqli_query($mysqli, "ALTER TABLE `assets` ADD `asset_physical_location` VARCHAR(200) DEFAULT NULL AFTER `asset_photo`");
-    
+
         mysqli_query($mysqli, "UPDATE `settings` SET `config_current_database_version` = '1.4.1'");
     }
 
-    // if (CURRENT_DATABASE_VERSION == '1.4.1') {
-    //     // Insert queries here required to update to DB version 1.4.2
+    if (CURRENT_DATABASE_VERSION == '1.4.1') {
+        mysqli_query($mysqli, "ALTER TABLE `settings` ADD `config_log_retention` INT(11) NOT NULL DEFAULT '90' AFTER `config_login_remember_me_expire`;");
+        mysqli_query($mysqli, "UPDATE `settings` SET `config_log_retention` = '2555' WHERE company_id = 1;"); // Set to 7 years for existing installs
+
+        mysqli_query($mysqli, "UPDATE `settings` SET `config_current_database_version` = '1.4.2'");
+    }
+
+    // if (CURRENT_DATABASE_VERSION == '1.4.2') {
+    //     // Insert queries here required to update to DB version 1.4.3
     //     // Then, update the database to the next sequential version
-    //     mysqli_query($mysqli, "UPDATE `settings` SET `config_current_database_version` = '1.4.2'");
+    //     mysqli_query($mysqli, "UPDATE `settings` SET `config_current_database_version` = '1.4.3'");
     // }
 
 } else {

--- a/database_version.php
+++ b/database_version.php
@@ -5,4 +5,4 @@
  * It is used in conjunction with database_updates.php
  */
 
-DEFINE("LATEST_DATABASE_VERSION", "1.4.1");
+DEFINE("LATEST_DATABASE_VERSION", "1.4.2");

--- a/db.sql
+++ b/db.sql
@@ -1501,6 +1501,7 @@ CREATE TABLE `settings` (
   `config_login_key_required` tinyint(1) NOT NULL DEFAULT 0,
   `config_login_key_secret` varchar(255) DEFAULT NULL,
   `config_login_remember_me_expire` int(11) NOT NULL DEFAULT 3,
+  `config_log_retention` int(11) NOT NULL DEFAULT 90,
   `config_module_enable_ticketing` tinyint(1) NOT NULL DEFAULT 1,
   `config_theme` varchar(200) DEFAULT 'blue',
   `config_telemetry` tinyint(1) DEFAULT 0,

--- a/get_settings.php
+++ b/get_settings.php
@@ -113,6 +113,7 @@ $config_login_message = $row['config_login_message'];
 $config_login_key_required = $row['config_login_key_required'];
 $config_login_key_secret = $row['config_login_key_secret'];
 $config_login_remember_me_expire = intval($row['config_login_remember_me_expire']);
+$config_log_retention = intval($row['config_log_retention']);
 
 // Locale
 $config_currency_format = "US_en";

--- a/post/setting.php
+++ b/post/setting.php
@@ -545,8 +545,9 @@ if (isset($_POST['edit_security_settings'])) {
     $config_login_key_required = intval($_POST['config_login_key_required']);
     $config_login_key_secret = sanitizeInput($_POST['config_login_key_secret']);
     $config_login_remember_me_expire = intval($_POST['config_login_remember_me_expire']);
+    $config_log_retention = intval($_POST['config_log_retention']);
 
-    mysqli_query($mysqli,"UPDATE settings SET config_login_message = '$config_login_message', config_login_key_required = '$config_login_key_required', config_login_key_secret = '$config_login_key_secret', config_login_remember_me_expire = $config_login_remember_me_expire WHERE company_id = 1");
+    mysqli_query($mysqli,"UPDATE settings SET config_login_message = '$config_login_message', config_login_key_required = '$config_login_key_required', config_login_key_secret = '$config_login_key_secret', config_login_remember_me_expire = $config_login_remember_me_expire, config_log_retention = $config_log_retention WHERE company_id = 1");
 
     // Logging
     mysqli_query($mysqli,"INSERT INTO logs SET log_type = 'Settings', log_action = 'Modify', log_description = '$session_name modified login key settings', log_ip = '$session_ip', log_user_agent = '$session_user_agent', log_user_id = $session_user_id");

--- a/settings_security.php
+++ b/settings_security.php
@@ -43,6 +43,16 @@ require_once "inc_all_admin.php";
                 </div>
             </div>
 
+            <div class="form-group">
+                <label>Log retention <small class="text-secondary">(The amount of days before audit logs are deleted during nightly cron)</small></label>
+                <div class="input-group">
+                    <div class="input-group-prepend">
+                        <span class="input-group-text"><i class="fa fa-fw fa-clock"></i></span>
+                    </div>
+                    <input type="number" class="form-control" name="config_log_retention" placeholder="Enter days to retain" value="<?php echo intval($config_log_retention); ?>">
+                </div>
+            </div>
+
             <hr>
 
             <button type="submit" name="edit_security_settings" class="btn btn-primary text-bold"><i class="fas fa-check mr-2"></i>Save</button>


### PR DESCRIPTION
Audit logs will be automatically cleaned up after 90 days (new installs) or 7 years (existing installs, in-case there is a compliance requirement for some of our existing users). 

This is configurable in Settings > Security.

![image](https://github.com/itflow-org/itflow/assets/32306651/d80f9413-38eb-42f2-b853-1e70cdc470cf)
