### PR TITLE
Add unknown/anonymous email to ticket parsing

### DIFF
--- a/cron_ticket_email_parser.php
+++ b/cron_ticket_email_parser.php
@@ -22,6 +22,7 @@ require_once "get_settings.php";
 
 $config_ticket_prefix = sanitizeInput($config_ticket_prefix);
 $config_ticket_from_name = sanitizeInput($config_ticket_from_name);
+$config_ticket_email_parse_unknown_senders = intval($row['config_ticket_email_parse_unknown_senders']);
 
 // Get company name & phone & timezone
 $sql = mysqli_query($mysqli, "SELECT * FROM companies, settings WHERE companies.company_id = settings.company_id AND companies.company_id = 1");
@@ -132,7 +133,7 @@ function addTicket($contact_id, $contact_name, $contact_email, $client_id, $date
     }
 
     $data = [];
-    if ($config_ticket_client_general_notifications == 1) {
+    if ($config_ticket_client_general_notifications == 1 && $client_id != 0) {
         $subject_email = "Ticket created - [$config_ticket_prefix$ticket_number] - $subject";
         $body = "<i style='color: #808080'>##- Please type your reply above this line -##</i><br><br>Hello $contact_name,<br><br>Thank you for your email. A ticket regarding \"$subject\" has been automatically created for you.<br><br>Ticket: $config_ticket_prefix$ticket_number<br>Subject: $subject<br>Status: New<br>https://$config_base_url/portal/ticket.php?id=$id<br><br>--<br>$company_name - Support<br>$config_ticket_from_email<br>$company_phone";
 
@@ -414,6 +415,12 @@ if ($messages->count() > 0) {
                     mysqli_query($mysqli, "INSERT INTO logs SET log_type = 'Contact', log_action = 'Create', log_description = 'Email parser: created contact ".mysqli_real_escape_string($mysqli, $contact_name)."', log_client_id = $client_id");
 
                     if (addTicket($contact_id, $contact_name, $contact_email, $client_id, $date, $subject, $message_body, $message->getAttachments(), $original_message_file)) {
+                        $email_processed = true;
+                    }
+                } else if ($config_ticket_email_parse_unknown_senders)  {
+                    // Parse even if the sender is unknown
+
+                    if (addTicket(0, 'Guest', $from_email, 0, $date, $subject, $message_body, $message->getAttachments(), $original_message_file)) {
                         $email_processed = true;
                     }
                 }

--- a/cron_ticket_email_parser.php
+++ b/cron_ticket_email_parser.php
@@ -417,7 +417,7 @@ if ($messages->count() > 0) {
                     if (addTicket($contact_id, $contact_name, $contact_email, $client_id, $date, $subject, $message_body, $message->getAttachments(), $original_message_file)) {
                         $email_processed = true;
                     }
-                } else if ($config_ticket_email_parse_unknown_senders)  {
+                } elseif ($config_ticket_email_parse_unknown_senders)  {
                     // Parse even if the sender is unknown
 
                     if (addTicket(0, 'Guest', $from_email, 0, $date, $subject, $message_body, $message->getAttachments(), $original_message_file)) {

--- a/database_updates.php
+++ b/database_updates.php
@@ -2085,9 +2085,15 @@ if (LATEST_DATABASE_VERSION > CURRENT_DATABASE_VERSION) {
     }
 
     // if (CURRENT_DATABASE_VERSION == '1.4.2') {
-    //     // Insert queries here required to update to DB version 1.4.3
+    mysqli_query($mysqli, "ALTER TABLE `settings` ADD `config_ticket_email_parse_unknown_senders` INT(1) NOT NULL DEFAULT '0' AFTER `config_ticket_email_parse`");
+
+    mysqli_query($mysqli, "UPDATE `settings` SET `config_current_database_version` = '1.4.3'");
+    // }
+
+    // if (CURRENT_DATABASE_VERSION == '1.4.3') {
+    //     // Insert queries here required to update to DB version 1.4.4
     //     // Then, update the database to the next sequential version
-    //     mysqli_query($mysqli, "UPDATE `settings` SET `config_current_database_version` = '1.4.3'");
+    //     mysqli_query($mysqli, "UPDATE `settings` SET `config_current_database_version` = '1.4.4'");
     // }
 
 } else {

--- a/database_version.php
+++ b/database_version.php
@@ -5,4 +5,4 @@
  * It is used in conjunction with database_updates.php
  */
 
-DEFINE("LATEST_DATABASE_VERSION", "1.4.2");
+DEFINE("LATEST_DATABASE_VERSION", "1.4.3");

--- a/db.sql
+++ b/db.sql
@@ -1467,6 +1467,7 @@ CREATE TABLE `settings` (
   `config_ticket_from_name` varchar(200) DEFAULT NULL,
   `config_ticket_from_email` varchar(200) DEFAULT NULL,
   `config_ticket_email_parse` tinyint(1) NOT NULL DEFAULT 0,
+  `config_ticket_email_parse_unknown_senders` tinyint(1) NOT NULL DEFAULT 0,
   `config_ticket_client_general_notifications` tinyint(1) NOT NULL DEFAULT 1,
   `config_ticket_autoclose` tinyint(1) NOT NULL DEFAULT 0,
   `config_ticket_autoclose_hours` int(5) NOT NULL DEFAULT 72,

--- a/get_settings.php
+++ b/get_settings.php
@@ -68,11 +68,13 @@ $config_ticket_next_number = intval($row['config_ticket_next_number']);
 $config_ticket_from_name = $row['config_ticket_from_name'];
 $config_ticket_from_email = $row['config_ticket_from_email'];
 $config_ticket_email_parse = intval($row['config_ticket_email_parse']);
+$config_ticket_email_parse_unknown_senders = intval($row['config_ticket_email_parse_unknown_senders']);
 $config_ticket_client_general_notifications = intval($row['config_ticket_client_general_notifications']);
 $config_ticket_autoclose = intval($row['config_ticket_autoclose']);
 $config_ticket_autoclose_hours = intval($row['config_ticket_autoclose_hours']);
 $config_ticket_new_ticket_notification_email = $row['config_ticket_new_ticket_notification_email'];
 $config_ticket_default_billable = intval($row['config_ticket_default_billable']);
+
 
 // Cron
 $config_enable_cron = intval($row['config_enable_cron']);

--- a/post/setting.php
+++ b/post/setting.php
@@ -306,12 +306,13 @@ if (isset($_POST['edit_ticket_settings'])) {
     $config_ticket_prefix = sanitizeInput($_POST['config_ticket_prefix']);
     $config_ticket_next_number = intval($_POST['config_ticket_next_number']);
     $config_ticket_email_parse = intval($_POST['config_ticket_email_parse']);
+    $config_ticket_email_parse_unknown_senders = intval($_POST['config_ticket_email_parse_unknown_senders']);
     $config_ticket_default_billable = intval($_POST['config_ticket_default_billable']);
     $config_ticket_autoclose = intval($_POST['config_ticket_autoclose']);
     $config_ticket_autoclose_hours = intval($_POST['config_ticket_autoclose_hours']);
     $config_ticket_new_ticket_notification_email = sanitizeInput($_POST['config_ticket_new_ticket_notification_email']);
 
-    mysqli_query($mysqli,"UPDATE settings SET config_ticket_prefix = '$config_ticket_prefix', config_ticket_next_number = $config_ticket_next_number, config_ticket_email_parse = $config_ticket_email_parse, config_ticket_autoclose = $config_ticket_autoclose, config_ticket_autoclose_hours = $config_ticket_autoclose_hours, config_ticket_new_ticket_notification_email = '$config_ticket_new_ticket_notification_email', config_ticket_default_billable = $config_ticket_default_billable WHERE company_id = 1");
+    mysqli_query($mysqli,"UPDATE settings SET config_ticket_prefix = '$config_ticket_prefix', config_ticket_next_number = $config_ticket_next_number, config_ticket_email_parse = $config_ticket_email_parse, config_ticket_email_parse_unknown_senders = $config_ticket_email_parse_unknown_senders, config_ticket_autoclose = $config_ticket_autoclose, config_ticket_autoclose_hours = $config_ticket_autoclose_hours, config_ticket_new_ticket_notification_email = '$config_ticket_new_ticket_notification_email', config_ticket_default_billable = $config_ticket_default_billable WHERE company_id = 1");
 
     //Logging
     mysqli_query($mysqli,"INSERT INTO logs SET log_type = 'Settings', log_action = 'Modify', log_description = '$session_name modified ticket settings', log_ip = '$session_ip', log_user_agent = '$session_user_agent', log_user_id = $session_user_id");

--- a/settings_ticket.php
+++ b/settings_ticket.php
@@ -10,6 +10,7 @@ require_once "inc_all_admin.php";
             <form action="post.php" method="post" autocomplete="off">
                 <input type="hidden" name="csrf_token" value="<?php echo $_SESSION['csrf_token'] ?>">
                 <input type="hidden" name="config_ticket_email_parse" value="0">
+                <input type="hidden" name="config_ticket_email_parse_unknown_senders" value="0">
                 <input type="hidden" name="config_ticket_autoclose" value="0">
                 <input type="hidden" name="config_ticket_default_billable" value="0">
 
@@ -37,6 +38,13 @@ require_once "inc_all_admin.php";
                     <div class="custom-control custom-switch">
                         <input type="checkbox" class="custom-control-input" name="config_ticket_email_parse" <?php if($config_ticket_email_parse == 1){ echo "checked"; } ?> value="1" id="emailToTicketParseSwitch">
                         <label class="custom-control-label" for="emailToTicketParseSwitch">Email-to-ticket parsing <small class="text-secondary">(cron_ticket_email_parser.php must also be added to cron and run every few mins)</small></label>
+                    </div>
+                </div>
+
+                <div class="form-group">
+                    <div class="custom-control custom-switch">
+                        <input type="checkbox" class="custom-control-input" name="config_ticket_email_parse_unknown_senders" <?php if($config_ticket_email_parse_unknown_senders == 1){ echo "checked"; } ?> value="1" id="emailToTicketAnonParseSwitch" <?php if($config_ticket_email_parse == 0){ echo "disabled"; } ?>>
+                        <label class="custom-control-label" for="emailToTicketAnonParseSwitch">Create tickets for emails from unknown senders/domains <small class="text-secondary">(Enable to ensure all emails automatically create tickets)</small></label>
                     </div>
                 </div>
 


### PR DESCRIPTION
Add option to allow unknown/anonymous email parsing for unknown contacts/domains. 
This will be disabled by default due to the potential for spam, but can be turned on in the settings if required.