### PR TITLE
Only show most current version of a document in the client portal

### DIFF
--- a/portal/documents.php
+++ b/portal/documents.php
@@ -13,7 +13,7 @@ if ($session_contact_primary == 0 && !$session_contact_is_technical_contact) {
     exit();
 }
 
-$documents_sql = mysqli_query($mysqli, "SELECT document_id, document_name, document_created_at, folder_name FROM documents LEFT JOIN folders ON document_folder_id = folder_id WHERE document_client_id = $session_client_id AND document_template = 0 ORDER BY folder_id, document_name DESC");
+$documents_sql = mysqli_query($mysqli, "SELECT document_id, document_name, document_created_at, folder_name FROM documents LEFT JOIN folders ON document_folder_id = folder_id WHERE document_client_id = $session_client_id AND document_template = 0 AND document_archived_at IS NULL ORDER BY folder_id, document_name DESC");
 ?>
 
 <div class="row">


### PR DESCRIPTION
Currently all revisions are shown in the client portal, which is confusing.