### PR TITLE
Bugfix: credentials

### DIFF
--- a/client_logins.php
+++ b/client_logins.php
@@ -44,7 +44,7 @@ $num_rows = mysqli_fetch_row(mysqli_query($mysqli, "SELECT FOUND_ROWS()"));
         <h3 class="card-title mt-2"><i class="fa fa-fw fa-key mr-2"></i>Credentials</h3>
         <div class="card-tools">
             <div class="btn-group">
-                <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#addLoginModal">
+                <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#addLoginModal" <?php if (!isset($_COOKIE['user_encryption_session_key'])) { echo "disabled"; } ?>>
                     <i class="fas fa-plus mr-2"></i>New Credential
                 </button>
                 <button type="button" class="btn btn-primary dropdown-toggle dropdown-toggle-split" data-toggle="dropdown"></button>

--- a/login.php
+++ b/login.php
@@ -145,7 +145,7 @@ if (isset($_POST['login'])) {
         }
 
         // Validate MFA code
-        if (TokenAuth6238::verify($token, $current_code)) {
+        if (!empty($current_code) && TokenAuth6238::verify($token, $current_code)) {
             $mfa_is_complete = true;
             $extended_log = 'with 2FA';
         }


### PR DESCRIPTION
Fix an edge-case bug causing the user_encryption_session_key session cookie to not be set due to error output (when display PHP errors in browser is enabled). This means login credentials are still encrypted but cannot be decrypted properly by other users. 

As a failsafe, prevent users creating new credentials if they do not have the correct cookie set.

_This is the first time in 2+ years I've run into this, and only because I've setup a new dev env. I don't think it's a common issue by any means but doesn't hurt to fix._