### PR TITLE
Ticket next number should not be lower than the last ticket number

### DIFF
--- a/settings_ticket.php
+++ b/settings_ticket.php
@@ -29,7 +29,7 @@ require_once "inc_all_admin.php";
                         <div class="input-group-prepend">
                             <span class="input-group-text"><i class="fa fa-fw fa-barcode"></i></span>
                         </div>
-                        <input type="number" min="0" class="form-control" name="config_ticket_next_number" placeholder="Next Ticket Number" value="<?php echo intval($config_ticket_next_number); ?>" required>
+                        <input type="number" min="<?php echo intval($config_ticket_next_number); ?>" class="form-control" name="config_ticket_next_number" placeholder="Next Ticket Number" value="<?php echo intval($config_ticket_next_number); ?>" required>
                     </div>
                 </div>
 


### PR DESCRIPTION
If the number is allowed to be lower, we will get collisions when trying to merge tickets or parse email subjects.