### PR TITLE
Update expenses.php

### DIFF
--- a/expenses.php
+++ b/expenses.php
@@ -293,7 +293,9 @@ $num_rows = mysqli_fetch_row(mysqli_query($mysqli, "SELECT FOUND_ROWS()"));
                             if (empty($expense_receipt)) {
                                 $receipt_attached = "";
                             } else {
-                                $receipt_attached = "<a class='text-secondary mr-2' target='_blank' href='uploads/expenses/$expense_receipt' download='$expense_date-$vendor_name-$category_name-$expense_id.pdf'><i class='fa fa-file-pdf'></i></a>";
+                                $path_info = pathinfo($expense_receipt);
+                                $ext = $path_info['extension'];
+                                $receipt_attached = "<a class='text-secondary mr-2' target='_blank' href='uploads/expenses/$expense_receipt' download='$expense_date-$vendor_name-$category_name-$expense_id.$ext'><i class='fa fa-file'></i></a>";
                             }
 
                             ?>


### PR DESCRIPTION
Downloaded filename extension was hardcoded for PDF and downloads any jpg/png as a PDF file. This fix takes into account the database filename and extension and updated icon to general file.