### PR TITLE
Add custom event handler 

### DIFF
--- a/cron.php
+++ b/cron.php
@@ -152,7 +152,7 @@ if ($config_whitelabel_enabled && !validateWhitelabelKey($config_whitelabel_key)
 
 // DOMAINS EXPIRING
 
-if($config_enable_alert_domain_expire == 1){
+if ($config_enable_alert_domain_expire == 1) {
 
     $domainAlertArray = [1,7,14,30,90];
 
@@ -247,7 +247,7 @@ $sql_tickets_pending_assignment = mysqli_query($mysqli,"SELECT ticket_id FROM ti
 
 $tickets_pending_assignment = mysqli_num_rows($sql_tickets_pending_assignment);
 
-if($tickets_pending_assignment > 0){
+if ($tickets_pending_assignment > 0) {
 
     mysqli_query($mysqli, "INSERT INTO notifications SET notification_type = 'Pending Tickets', notification = 'There are $tickets_pending_assignment new tickets pending assignment', notification_action = 'tickets.php?status=New'");
 
@@ -294,6 +294,8 @@ if (mysqli_num_rows($sql_scheduled_tickets) > 0) {
 
         // Logging
         mysqli_query($mysqli, "INSERT INTO logs SET log_type = 'Ticket', log_action = 'Create', log_description = 'System created recurring scheduled $frequency ticket - $subject', log_client_id = $client_id, log_user_id = $created_id");
+
+        customAction('ticket_create', $id);
 
         // Notifications
 
@@ -414,6 +416,8 @@ while ($row = mysqli_fetch_array($sql_resolved_tickets_to_close)) {
 
     //Logging
     mysqli_query($mysqli,"INSERT INTO logs SET log_type = 'Ticket', log_action = 'Closed', log_description = '$ticket_prefix$ticket_number auto closed', log_entity_id = $ticket_id");
+
+    customAction('ticket_close', $ticket_id);
 
     //TODO: Add client notifs if $config_ticket_client_general_notifications is on
 }
@@ -568,6 +572,8 @@ while ($row = mysqli_fetch_array($sql_recurring)) {
     mysqli_query($mysqli, "INSERT INTO history SET history_status = 'Sent', history_description = 'Invoice Generated from Recurring!', history_invoice_id = $new_invoice_id");
 
     mysqli_query($mysqli, "INSERT INTO notifications SET notification_type = 'Recurring Sent', notification = 'Recurring Invoice $config_invoice_prefix$new_invoice_number for $client_name Sent', notification_action = 'invoice.php?invoice_id=$new_invoice_id', notification_client_id = $client_id, notification_entity_id = $new_invoice_id");
+
+    customAction('invoice_create', $new_invoice_id);
 
     //Update recurring dates
 

--- a/functions.php
+++ b/functions.php
@@ -1304,10 +1304,18 @@ function enforceUserPermission($module, $check_access_level = 1) {
     }
 }
 
+// TODO: Probably remove this
 function enforceAdminPermission() {
     global $session_is_admin;
     if (!isset($session_is_admin) || !$session_is_admin) {
         exit(WORDING_ROLECHECK_FAILED . "<br>Tell your admin: Your role does not have admin access.");
     }
     return true;
+}
+
+function customAction($trigger, $entity) {
+    chdir(dirname(__FILE__));
+    if (file_exists(__DIR__ . "/xcustom/xcustom_action_handler.php")) {
+        include_once __DIR__ . "/xcustom/xcustom_action_handler.php";
+    }
 }

--- a/guest_pay_invoice_stripe.php
+++ b/guest_pay_invoice_stripe.php
@@ -283,6 +283,7 @@ if (isset($_GET['invoice_id'], $_GET['url_key']) && !isset($_GET['payment_intent
 
     // Notify
     mysqli_query($mysqli, "INSERT INTO notifications SET notification_type = 'Invoice Paid', notification = 'Invoice $invoice_prefix$invoice_number has been paid by $client_name - $ip - $os - $browser', notification_action = 'invoice.php?invoice_id=$invoice_id', notification_client_id = $pi_client_id");
+    customAction('invoice_pay', $invoice_id);
 
     // Logging
     $extended_log_desc = '';

--- a/guest_post.php
+++ b/guest_post.php
@@ -23,6 +23,8 @@ if (isset($_GET['accept_quote'], $_GET['url_key'])) {
 
         mysqli_query($mysqli, "INSERT INTO history SET history_status = 'Accepted', history_description = 'Client accepted Quote!', history_quote_id = $quote_id");
 
+        customAction('quote_accept', $quote_id);
+
         $_SESSION['alert_message'] = "Quote Accepted";
 
         header("Location: " . $_SERVER["HTTP_REFERER"]);
@@ -44,6 +46,8 @@ if (isset($_GET['decline_quote'], $_GET['url_key'])) {
         mysqli_query($mysqli, "UPDATE quotes SET quote_status = 'Declined' WHERE quote_id = $quote_id");
 
         mysqli_query($mysqli, "INSERT INTO history SET history_status = 'Declined', history_description = 'Client declined Quote!', history_quote_id = $quote_id");
+
+        customAction('quote_decline', $quote_id);
 
         $_SESSION['alert_type'] = "danger";
         $_SESSION['alert_message'] = "Quote Declined";
@@ -73,6 +77,8 @@ if (isset($_GET['reopen_ticket'], $_GET['url_key'])) {
         //Logging
         mysqli_query($mysqli, "INSERT INTO logs SET log_type = 'Ticket', log_action = 'Replied', log_description = '$ticket_id reopened by client (guest)', log_ip = '$session_ip', log_user_agent = '$session_user_agent'");
 
+        customAction('ticket_update', $ticket_id);
+
         $_SESSION['alert_message'] = "Ticket reopened";
         header("Location: " . $_SERVER["HTTP_REFERER"]);
 
@@ -99,6 +105,8 @@ if (isset($_GET['close_ticket'], $_GET['url_key'])) {
 
         //Logging
         mysqli_query($mysqli, "INSERT INTO logs SET log_type = 'Ticket', log_action = 'Replied', log_description = '$ticket_id closed by client (guest)', log_ip = '$session_ip', log_user_agent = '$session_user_agent'");
+
+        customAction('ticket_close', $ticket_id);
 
         $_SESSION['alert_message'] = "Ticket closed";
         header("Location: " . $_SERVER["HTTP_REFERER"]);
@@ -129,6 +137,8 @@ if (isset($_GET['add_ticket_feedback'], $_GET['url_key'])) {
 
         $_SESSION['alert_message'] = "Feedback recorded - thank you";
         header("Location: " . $_SERVER["HTTP_REFERER"]);
+
+        customAction('ticket_feedback', $ticket_id);
 
     } else {
         echo "Invalid!!";

--- a/portal/portal_post.php
+++ b/portal/portal_post.php
@@ -37,7 +37,7 @@ if (isset($_POST['add_ticket'])) {
     mysqli_query($mysqli, "UPDATE settings SET config_ticket_next_number = $new_config_ticket_next_number WHERE company_id = 1");
 
     mysqli_query($mysqli, "INSERT INTO tickets SET ticket_prefix = '$config_ticket_prefix', ticket_number = $ticket_number, ticket_subject = '$subject', ticket_details = '$details', ticket_priority = '$priority', ticket_status = 1, ticket_created_by = 0, ticket_contact_id = $contact, ticket_url_key = '$url_key', ticket_client_id = $client_id");
-    $id = mysqli_insert_id($mysqli);
+    $ticket_id = mysqli_insert_id($mysqli);
 
     // Notify agent DL of the new ticket, if populated with a valid email
     if ($config_ticket_new_ticket_notification_email) {
@@ -46,7 +46,7 @@ if (isset($_POST['add_ticket'])) {
         $details = removeEmoji($details);
 
         $email_subject = "ITFlow - New Ticket - $client_name: $subject";
-        $email_body = "Hello, <br><br>This is a notification that a new ticket has been raised in ITFlow. <br>Client: $client_name<br>Priority: $priority<br>Link: https://$config_base_url/ticket.php?ticket_id=$id <br><br><b>$subject</b><br>$details";
+        $email_body = "Hello, <br><br>This is a notification that a new ticket has been raised in ITFlow. <br>Client: $client_name<br>Priority: $priority<br>Link: https://$config_base_url/ticket.php?ticket_id=$ticket_id <br><br><b>$subject</b><br>$details";
 
         // Queue Mail
         $data = [
@@ -62,10 +62,13 @@ if (isset($_POST['add_ticket'])) {
         addToMailQueue($mysqli, $data);
         }
 
+    // Custom action/notif handler
+    customAction('ticket_create', $ticket_id);
+
     // Logging
     mysqli_query($mysqli, "INSERT INTO logs SET log_type = 'Ticket', log_action = 'Create', log_description = 'Client contact $session_contact_name created ticket $subject', log_ip = '$session_ip', log_user_agent = '$session_user_agent', log_client_id = $client_id");
 
-    header("Location: ticket.php?id=" . $id);
+    header("Location: ticket.php?id=" . $ticket_id);
 
 }
 
@@ -162,6 +165,9 @@ if (isset($_POST['add_ticket_comment'])) {
             }
         }
 
+        // Custom action/notif handler
+        customAction('ticket_reply_client', $ticket_id);
+
         // Redirect back to original page
         header("Location: " . $_SERVER["HTTP_REFERER"]);
 
@@ -186,6 +192,9 @@ if (isset($_POST['add_ticket_feedback'])) {
         if ($feedback == "Bad") {
             mysqli_query($mysqli, "INSERT INTO notifications SET notification_type = 'Feedback', notification = '$session_contact_name rated ticket ID $ticket_id as bad', notification_client_id = $session_client_id");
         }
+
+        // Custom action/notif handler
+        customAction('ticket_feedback', $ticket_id);
 
         // Redirect
         header("Location: " . $_SERVER["HTTP_REFERER"]);
@@ -212,7 +221,12 @@ if (isset($_GET['resolve_ticket'])) {
         //Logging
         mysqli_query($mysqli, "INSERT INTO logs SET log_type = 'Ticket', log_action = 'Resolved', log_description = '$ticket_id resolved by client', log_ip = '$session_ip', log_user_agent = '$session_user_agent'");
 
+        // Custom action/notif handler
+        customAction('ticket_resolve', $ticket_id);
+        exit;
+
         header("Location: ticket.php?id=" . $ticket_id);
+
     } else {
         // The client does not have access to this ticket - send them home
         header("Location: index.php");
@@ -235,7 +249,11 @@ if (isset($_GET['reopen_ticket'])) {
         //Logging
         mysqli_query($mysqli, "INSERT INTO logs SET log_type = 'Ticket', log_action = 'Replied', log_description = '$ticket_id reopened by client', log_ip = '$session_ip', log_user_agent = '$session_user_agent'");
 
+        // Custom action/notif handler
+        customAction('ticket_update', $ticket_id);
+
         header("Location: ticket.php?id=" . $ticket_id);
+
     } else {
         // The client does not have access to this ticket - send them home
         header("Location: index.php");
@@ -257,6 +275,9 @@ if (isset($_GET['close_ticket'])) {
 
         //Logging
         mysqli_query($mysqli, "INSERT INTO logs SET log_type = 'Ticket', log_action = 'Closed', log_description = '$ticket_id closed by client', log_ip = '$session_ip', log_user_agent = '$session_user_agent'");
+
+        // Custom action/notif handler
+        customAction('ticket_close', $ticket_id);
 
         header("Location: ticket.php?id=" . $ticket_id);
     } else {
@@ -303,6 +324,8 @@ if (isset($_POST['edit_contact'])) {
 
     $_SESSION['alert_message'] = "Contact updated";
     header('Location: contacts.php');
+
+    customAction('contact_update', $ticket_id);
 }
 
 if (isset($_POST['add_contact'])) {
@@ -316,6 +339,8 @@ if (isset($_POST['add_contact'])) {
 
     // Logging
     mysqli_query($mysqli, "INSERT INTO logs SET log_type = 'Contact', log_action = 'Create', log_description = 'Client $session_contact_name created contact $contact_name', log_ip = '$session_ip', log_user_agent = '$session_user_agent', log_client_id = $session_client_id");
+
+    customAction('contact_create', $ticket_id);
 
     $_SESSION['alert_message'] = "Contact created";
     header('Location: contacts.php');

--- a/post/user/contact.php
+++ b/post/user/contact.php
@@ -10,7 +10,6 @@ if (isset($_POST['add_contact'])) {
 
     require_once 'post/user/contact_model.php';
 
-
     // Set password
     if (!empty($_POST['contact_password'])) {
         $password_hash = password_hash(trim($_POST['contact_password']), PASSWORD_DEFAULT);
@@ -57,6 +56,8 @@ if (isset($_POST['add_contact'])) {
 
     //Logging
     mysqli_query($mysqli,"INSERT INTO logs SET log_type = 'Contact', log_action = 'Create', log_description = '$session_name created contact $name', log_ip = '$session_ip', log_user_agent = '$session_user_agent', log_client_id = $client_id, log_user_id = $session_user_id, log_entity_id = $contact_id");
+
+    customAction('contact_create', $contact_id);
 
     $_SESSION['alert_message'] = "Contact <strong>$name</strong> created";
 
@@ -172,6 +173,8 @@ if (isset($_POST['edit_contact'])) {
 
     //Logging
     mysqli_query($mysqli,"INSERT INTO logs SET log_type = 'Contact', log_action = 'Modify', log_description = '$session_name modified contact $name', log_ip = '$session_ip', log_user_agent = '$session_user_agent', log_client_id = $client_id, log_user_id = $session_user_id, log_entity_id = $contact_id");
+
+    customAction('contact_update', $contact_id);
 
     $_SESSION['alert_message'] = "Contact <strong>$name</strong> updated";
 
@@ -312,6 +315,8 @@ if (isset($_POST['bulk_edit_contact_role'])) {
 
             //Logging
             mysqli_query($mysqli,"INSERT INTO logs SET log_type = 'Contact', log_action = 'Modify', log_description = '$session_name updated $contact_name role', log_ip = '$session_ip', log_user_agent = '$session_user_agent', log_client_id = $client_id, log_user_id = $session_user_id, log_entity_id = $contact_id");
+
+            customAction('contact_update', $contact_id);
 
         } // End Assign Location Loop
 

--- a/post/user/invoice.php
+++ b/post/user/invoice.php
@@ -31,6 +31,8 @@ if (isset($_POST['add_invoice'])) {
     //Logging
     mysqli_query($mysqli,"INSERT INTO logs SET log_type = 'Invoice', log_action = 'Create', log_description = '$config_invoice_prefix$invoice_number', log_ip = '$session_ip', log_user_agent = '$session_user_agent', log_user_id = $session_user_id");
 
+    customAction('invoice_create', $invoice_id);
+
     $_SESSION['alert_message'] = "Invoice added";
 
     header("Location: invoice.php?invoice_id=$invoice_id");
@@ -116,6 +118,8 @@ if (isset($_POST['add_invoice_copy'])) {
 
     //Logging
     mysqli_query($mysqli,"INSERT INTO logs SET log_type = 'Invoice', log_action = 'Create', log_description = 'Copied Invoice', log_ip = '$session_ip', log_user_agent = '$session_user_agent', log_user_id = $session_user_id");
+
+    customAction('invoice_create', $new_invoice_id);
 
     $_SESSION['alert_message'] = "Invoice copied";
 
@@ -748,6 +752,8 @@ if (isset($_POST['add_payment'])) {
         //Logging
         mysqli_query($mysqli,"INSERT INTO logs SET log_type = 'Payment', log_action = 'Create', log_description = '$payment_amount', log_ip = '$session_ip', log_user_agent = '$session_user_agent', log_client_id = $client_id, log_user_id = $session_user_id, log_entity_id = $payment_id");
 
+        customAction('invoice_pay', $invoice_id);
+
         if ($email_receipt == 1) {
             mysqli_query($mysqli,"INSERT INTO logs SET log_type = 'Payment', log_action = 'Email', log_description = 'Payment receipt for invoice $invoice_prefix$invoice_number queued to $contact_email Email ID: $email_id', log_ip = '$session_ip', log_user_agent = '$session_user_agent', log_client_id = $client_id, log_user_id = $session_user_id, log_entity_id = $payment_id");
         }
@@ -834,9 +840,9 @@ if (isset($_POST['add_bulk_payment'])) {
         mysqli_query($mysqli, $add_history_query);
 
         // Add to Email Body Invoice Portion
-
         $email_body_invoices .= "<br>Invoice <a href=\'https://$config_base_url/guest_view_invoice.php?invoice_id=$invoice_id&url_key=$invoice_url_key\'>$invoice_prefix$invoice_number</a> - Outstanding Amount: " . numfmt_format_currency($currency_format, $invoice_balance, $currency_code) . " - Payment Applied: " . numfmt_format_currency($currency_format, $payment_amount, $currency_code) . " - New Balance: " . numfmt_format_currency($currency_format, $remaining_invoice_balance, $currency_code);
 
+        customAction('invoice_pay', $invoice_id);
 
     } // End Invoice Loop
 
@@ -1208,6 +1214,8 @@ if (isset($_GET['force_recurring'])) {
 
     //Logging
     mysqli_query($mysqli,"INSERT INTO logs SET log_type = 'Invoice', log_action = 'Create', log_description = '$session_name forced recurring invoice into an invoice', log_ip = '$session_ip', log_user_agent = '$session_user_agent', log_client_id = $client_id, log_user_id = $session_user_id, log_entity_id = $new_invoice_id");
+
+    customAction('invoice_create', $new_invoice_id);
 
     $_SESSION['alert_message'] = "Recurring Invoice Forced";
 

--- a/post/user/quote.php
+++ b/post/user/quote.php
@@ -29,6 +29,8 @@ if (isset($_POST['add_quote'])) {
     //Logging
     mysqli_query($mysqli,"INSERT INTO logs SET log_type = 'Quote', log_action = 'Create', log_description = '$quote_prefix$quote_number', log_ip = '$session_ip', log_user_agent = '$session_user_agent', log_user_id = $session_user_id");
 
+    customAction('quote_create', $quote_id);
+
     $_SESSION['alert_message'] = "Quote added";
 
     header("Location: quote.php?quote_id=$quote_id");
@@ -85,6 +87,8 @@ if (isset($_POST['add_quote_copy'])) {
 
     //Logging
     mysqli_query($mysqli,"INSERT INTO logs SET log_type = 'Quote', log_action = 'Create', log_description = 'Copied Quote', log_ip = '$session_ip', log_user_agent = '$session_user_agent', log_client_id = $client_id, log_user_id = $session_user_id");
+
+    customAction('quote_create', $new_quote_id);
 
     $_SESSION['alert_message'] = "Quote copied";
 
@@ -144,6 +148,8 @@ if (isset($_POST['add_quote_to_invoice'])) {
 
     //Logging
     mysqli_query($mysqli,"INSERT INTO logs SET log_type = 'Quote', log_action = 'Create', log_description = 'Quote copied to Invoice', log_ip = '$session_ip', log_user_agent = '$session_user_agent', log_user_id = $session_user_id");
+
+    customAction('invoice_create', $new_invoice_id);
 
     $_SESSION['alert_message'] = "Quote copied to Invoice";
 
@@ -345,6 +351,8 @@ if (isset($_GET['accept_quote'])) {
     //Logging
     mysqli_query($mysqli,"INSERT INTO logs SET log_type = 'Quote', log_action = 'Modify', log_description = 'Accepted Quote $quote_id', log_ip = '$session_ip', log_user_agent = '$session_user_agent', log_user_id = $session_user_id");
 
+    customAction('quote_accept', $quote_id);
+
     $_SESSION['alert_message'] = "Quote accepted";
 
     header("Location: " . $_SERVER["HTTP_REFERER"]);
@@ -360,6 +368,8 @@ if (isset($_GET['decline_quote'])) {
     mysqli_query($mysqli,"UPDATE quotes SET quote_status = 'Declined' WHERE quote_id = $quote_id");
 
     mysqli_query($mysqli,"INSERT INTO history SET history_status = 'Cancelled', history_description = 'Quote declined!', history_quote_id = $quote_id");
+
+    customAction('quote_decline', $quote_id);
 
     //Logging
     mysqli_query($mysqli,"INSERT INTO logs SET log_type = 'Quote', log_action = 'Modify', log_description = 'Declined Quote $quote_id', log_ip = '$session_ip', log_user_agent = '$session_user_agent', log_user_id = $session_user_id");

--- a/post/xcustom/readme.php
+++ b/post/xcustom/readme.php
@@ -3,11 +3,11 @@
 /*
     - Custom Pages -
 
-    If you wish to add custom pages to ITFlow, add them to the root directory with the prefix "xcustom_"
-        e.g. If your page was called my_page_one, name it "xcustom_my_page_one.php"
+    If you wish to add custom pages to ITFlow, add them to the xcustom folder in the root directory with the prefix "xcustom_"
+        e.g. If your page was called my_page_one, name it "xcustom/xcustom_my_page_one.php"
     Note: If required, you can use the Custom Links module to have the page show on the user sidebar.
 
     To process POST data via your custom pages, create a file in this directory (post/xcustom) named after your page (e.g. xcustom_my_page_one.php).
-    The relevant file will be automatically loaded upon a POST request based on the referer - your form just needs to target the standard post.php.
+    The relevant file will be automatically loaded upon a POST request based on the referer - your form just needs to target the standard root/post.php.
 
  */

--- a/xcustom/readme.php
+++ b/xcustom/readme.php
@@ -1,0 +1,9 @@
+<?php
+
+/*
+
+- Custom Pages -
+
+    If you wish to add custom pages to ITFlow, add them to this directory with the prefix "xcustom_"
+
+*/


### PR DESCRIPTION
Some events in post.php and across the app (like raising a ticket) will now call an event handler. This will allow you to write your own PHP code to be run when certain things in ITFlow happen. 

The event handler will be passed the action that triggered them as $trigger (e.g. ticket_create) and the associated entity ID number as $entity (e.g. 145).

The event handler function checks for the presence of a PHP file in the xcustom directory called xcustom_action_handler.php and includes it in the page if it exists. The custom PHP code in xcustom_action_handler.php will be able to access the $trigger and $entity alongside the ITFlow database to perform the relevant lookups (e.g. checking the ticket contact & grabbing their mobile) and sending them a text via a third party.