### PR TITLE
Invoices - Send email notif when paid

### DIFF
--- a/admin_settings_invoice.php
+++ b/admin_settings_invoice.php
@@ -57,6 +57,16 @@ require_once "inc_all_admin.php";
                     <small class="text-secondary">We recommend updating the invoice footer to include policies on your late charges. This will be applied every 30 days after the invoice Due Date.</small>
                 </div>
 
+                <div class="form-group">
+                    <label>Email address to notify when invoices are paid online <small class="text-secondary">(Ideally a distribution list/shared mailbox)</small></label>
+                    <div class="input-group">
+                        <div class="input-group-prepend">
+                            <span class="input-group-text"><i class="fa fa-fw fa-bell"></i></span>
+                        </div>
+                        <input type="email" class="form-control" name="config_invoice_paid_notification_email" placeholder="Address to notify for paid invoices, leave bank for none" value="<?php echo nullable_htmlentities($config_invoice_paid_notification_email); ?>">
+                    </div>
+                </div>
+
                 <hr>
 
                 <h4>Recurring Invoice</h4>

--- a/database_updates.php
+++ b/database_updates.php
@@ -2231,10 +2231,16 @@ if (LATEST_DATABASE_VERSION > CURRENT_DATABASE_VERSION) {
         mysqli_query($mysqli, "UPDATE `settings` SET `config_current_database_version` = '1.5.2'");
     }
 
-    // if (CURRENT_DATABASE_VERSION == '1.5.2') {
-    //     // Insert queries here required to update to DB version 1.5.3
+     if (CURRENT_DATABASE_VERSION == '1.5.2') {
+         mysqli_query($mysqli, "ALTER TABLE `settings` ADD `config_invoice_paid_notification_email` VARCHAR(200) DEFAULT NULL AFTER `config_invoice_late_fee_percent`");
+
+         mysqli_query($mysqli, "UPDATE `settings` SET `config_current_database_version` = '1.5.3'");
+     }
+
+    // if (CURRENT_DATABASE_VERSION == '1.5.3') {
+    //     // Insert queries here required to update to DB version 1.5.4
     //     // Then, update the database to the next sequential version
-    //     mysqli_query($mysqli, "UPDATE `settings` SET `config_current_database_version` = '1.5.3'");
+    //     mysqli_query($mysqli, "UPDATE `settings` SET `config_current_database_version` = '1.5.4'");
     // }
 
 } else {

--- a/database_version.php
+++ b/database_version.php
@@ -5,4 +5,4 @@
  * It is used in conjunction with database_updates.php
  */
 
-DEFINE("LATEST_DATABASE_VERSION", "1.5.2");
+DEFINE("LATEST_DATABASE_VERSION", "1.5.3");

--- a/db.sql
+++ b/db.sql
@@ -1477,6 +1477,7 @@ CREATE TABLE `settings` (
   `config_invoice_from_email` varchar(200) DEFAULT NULL,
   `config_invoice_late_fee_enable` tinyint(1) NOT NULL DEFAULT 0,
   `config_invoice_late_fee_percent` decimal(5,2) NOT NULL DEFAULT 0.00,
+  `config_invoice_paid_notification_email` varchar(200) DEFAULT NULL,
   `config_recurring_prefix` varchar(200) DEFAULT NULL,
   `config_recurring_next_number` int(11) NOT NULL,
   `config_quote_prefix` varchar(200) DEFAULT NULL,

--- a/get_settings.php
+++ b/get_settings.php
@@ -46,6 +46,7 @@ $config_invoice_from_name = $row['config_invoice_from_name'];
 $config_invoice_from_email = $row['config_invoice_from_email'];
 $config_invoice_late_fee_enable = intval($row['config_invoice_late_fee_enable']);
 $config_invoice_late_fee_percent = floatval($row['config_invoice_late_fee_percent']);
+$config_invoice_paid_notification_email = $row['config_invoice_paid_notification_email'];
 
 // Recurring Invoices
 $config_recurring_prefix = $row['config_recurring_prefix'];

--- a/post/admin/admin_settings_invoice.php
+++ b/post/admin/admin_settings_invoice.php
@@ -11,9 +11,13 @@ if (isset($_POST['edit_invoice_settings'])) {
     $config_invoice_late_fee_percent = floatval($_POST['config_invoice_late_fee_percent']);
     $config_recurring_prefix = sanitizeInput($_POST['config_recurring_prefix']);
     $config_recurring_next_number = intval($_POST['config_recurring_next_number']);
+    $config_invoice_paid_notification_email = '';
+    if (filter_var($_POST['config_invoice_paid_notification_email'], FILTER_VALIDATE_EMAIL)) {
+        $config_invoice_paid_notification_email = sanitizeInput($_POST['config_invoice_paid_notification_email']);
+    }
 
 
-    mysqli_query($mysqli,"UPDATE settings SET config_invoice_prefix = '$config_invoice_prefix', config_invoice_next_number = $config_invoice_next_number, config_invoice_footer = '$config_invoice_footer', config_invoice_late_fee_enable = $config_invoice_late_fee_enable, config_invoice_late_fee_percent = $config_invoice_late_fee_percent, config_recurring_prefix = '$config_recurring_prefix', config_recurring_next_number = $config_recurring_next_number WHERE company_id = 1");
+    mysqli_query($mysqli,"UPDATE settings SET config_invoice_prefix = '$config_invoice_prefix', config_invoice_next_number = $config_invoice_next_number, config_invoice_footer = '$config_invoice_footer', config_invoice_late_fee_enable = $config_invoice_late_fee_enable, config_invoice_late_fee_percent = $config_invoice_late_fee_percent, config_invoice_paid_notification_email = '$config_invoice_paid_notification_email', config_recurring_prefix = '$config_recurring_prefix', config_recurring_next_number = $config_recurring_next_number WHERE company_id = 1");
 
     //Logging
     mysqli_query($mysqli,"INSERT INTO logs SET log_type = 'Settings', log_action = 'Edit', log_description = '$session_name edited invoice settings', log_ip = '$session_ip', log_user_agent = '$session_user_agent', log_user_id = $session_user_id");

--- a/post/admin/admin_settings_ticket.php
+++ b/post/admin/admin_settings_ticket.php
@@ -8,7 +8,10 @@ if (isset($_POST['edit_ticket_settings'])) {
     $config_ticket_email_parse_unknown_senders = intval($_POST['config_ticket_email_parse_unknown_senders']);
     $config_ticket_default_billable = intval($_POST['config_ticket_default_billable']);
     $config_ticket_autoclose_hours = intval($_POST['config_ticket_autoclose_hours']);
-    $config_ticket_new_ticket_notification_email = sanitizeInput($_POST['config_ticket_new_ticket_notification_email']);
+    $config_ticket_new_ticket_notification_email = '';
+    if (filter_var($_POST['config_ticket_new_ticket_notification_email'], FILTER_VALIDATE_EMAIL)) {
+        $config_ticket_new_ticket_notification_email = sanitizeInput($_POST['config_ticket_new_ticket_notification_email']);
+    }
 
     mysqli_query($mysqli,"UPDATE settings SET config_ticket_prefix = '$config_ticket_prefix', config_ticket_next_number = $config_ticket_next_number, config_ticket_email_parse = $config_ticket_email_parse, config_ticket_email_parse_unknown_senders = $config_ticket_email_parse_unknown_senders, config_ticket_autoclose_hours = $config_ticket_autoclose_hours, config_ticket_new_ticket_notification_email = '$config_ticket_new_ticket_notification_email', config_ticket_default_billable = $config_ticket_default_billable WHERE company_id = 1");
 


### PR DESCRIPTION
Similar to the new ticket email notifications, send an internal email when invoices are paid online (currently just via Stripe).