### PR TITLE
Fix typos in admin_settings

### DIFF
--- a/admin_settings_invoice.php
+++ b/admin_settings_invoice.php
@@ -63,7 +63,7 @@ require_once "inc_all_admin.php";
                         <div class="input-group-prepend">
                             <span class="input-group-text"><i class="fa fa-fw fa-bell"></i></span>
                         </div>
-                        <input type="email" class="form-control" name="config_invoice_paid_notification_email" placeholder="Address to notify for paid invoices, leave bank for none" value="<?php echo nullable_htmlentities($config_invoice_paid_notification_email); ?>">
+                        <input type="email" class="form-control" name="config_invoice_paid_notification_email" placeholder="Address to notify for paid invoices, leave blank for none" value="<?php echo nullable_htmlentities($config_invoice_paid_notification_email); ?>">
                     </div>
                 </div>
 

--- a/admin_settings_quote.php
+++ b/admin_settings_quote.php
@@ -41,7 +41,7 @@ require_once "inc_all_admin.php";
                         <div class="input-group-prepend">
                             <span class="input-group-text"><i class="fa fa-fw fa-bell"></i></span>
                         </div>
-                        <input type="email" class="form-control" name="config_quote_notification_email" placeholder="Address to notify for quote accept/declines, leave bank for none" value="<?php echo nullable_htmlentities($config_quote_notification_email); ?>">
+                        <input type="email" class="form-control" name="config_quote_notification_email" placeholder="Address to notify for quote accept/declines, leave blank for none" value="<?php echo nullable_htmlentities($config_quote_notification_email); ?>">
                     </div>
                 </div>
 

--- a/admin_settings_ticket.php
+++ b/admin_settings_ticket.php
@@ -69,7 +69,7 @@ require_once "inc_all_admin.php";
                         <div class="input-group-prepend">
                             <span class="input-group-text"><i class="fa fa-fw fa-bell"></i></span>
                         </div>
-                        <input type="email" class="form-control" name="config_ticket_new_ticket_notification_email" placeholder="Address to notify for new tickets, leave bank for none" value="<?php echo nullable_htmlentities($config_ticket_new_ticket_notification_email); ?>">
+                        <input type="email" class="form-control" name="config_ticket_new_ticket_notification_email" placeholder="Address to notify for new tickets, leave blank for none" value="<?php echo nullable_htmlentities($config_ticket_new_ticket_notification_email); ?>">
                     </div>
                 </div>
 


### PR DESCRIPTION
Fixed typos in placeholders. See commits for more details.

```... leave bank for none``` -> ```... leave blank for none```