### PR TITLE
Center Align the Comany Name in the side navigation

### DIFF
--- a/css/sidebar_navigation.css
+++ b/css/sidebar_navigation.css
@@ -1,0 +1,10 @@
+/*
+Center aligns ITFlow Company Name in the left navigation sidebar
+Adds center alignment to the adminlte class brand-text
+*/
+.brand-text {
+	text-align: center;
+	/*max-width: 300px;
+	white-space: normal;
+	word-wrap: break-word;*/
+}

--- a/header.php
+++ b/header.php
@@ -39,6 +39,7 @@ header("X-Frame-Options: DENY");
     <link href='plugins/daterangepicker/daterangepicker.css' rel='stylesheet' />
     <link href="plugins/toastr/toastr.min.css" rel="stylesheet">
     <link href="plugins/DataTables/datatables.min.css" rel="stylesheet">
+    <link href="/css/sidebar_navigation.css" rel="stylesheet" type="text/css">
 
     <!-- jQuery -->
     <script src="plugins/jquery/jquery.min.js"></script>


### PR DESCRIPTION
This pull request includes changes to the styling and structure of the navigation sidebar and header of the application.

Styling improvements:

* [`css/sidebar_navigation.css`](diffhunk://#diff-b0829033374000266ea6c30107f55c67d4e36f89f4f6ea4c14e65d1a5404371fR1-R10): Center aligns the ITFlow Company Name in the left navigation sidebar by adding center alignment to the `brand-text` class.

Header integration:

* [`header.php`](diffhunk://#diff-e7f789e333fc7ce27ae3d6999cca0b78637e8b96c734dea9aedb855b278b7eb9R42): Adds a link to the new `sidebar_navigation.css` file to ensure the updated styles are applied.