### PR TITLE
Stop using Source Sans Pro intermittently for some pages

### DIFF
--- a/login.php
+++ b/login.php
@@ -1,7 +1,7 @@
 <?php
 
 // Enforce a Content Security Policy for security against cross-site scripting
-header("Content-Security-Policy: default-src 'self' fonts.googleapis.com fonts.gstatic.com");
+header("Content-Security-Policy: default-src 'self'");
 
 if (!file_exists('config.php')) {
     header("Location: setup.php");
@@ -316,8 +316,7 @@ if (isset($_POST['login'])) {
 
     <!-- Theme style -->
     <link rel="stylesheet" href="dist/css/adminlte.min.css">
-    <!-- Google Font: Source Sans Pro -->
-    <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700" rel="stylesheet">
+
 </head>
 <body class="hold-transition login-page">
 

--- a/portal/certificates.php
+++ b/portal/certificates.php
@@ -4,7 +4,7 @@
 * Certificate listing for PTC / technical contacts
 */
 
-header("Content-Security-Policy: default-src 'self' fonts.googleapis.com fonts.gstatic.com");
+header("Content-Security-Policy: default-src 'self'");
 
 require_once "inc_portal.php";
 

--- a/portal/contact_add.php
+++ b/portal/contact_add.php
@@ -4,7 +4,7 @@
  * Contact management for PTC / technical contacts
  */
 
-header("Content-Security-Policy: default-src 'self' fonts.googleapis.com fonts.gstatic.com");
+header("Content-Security-Policy: default-src 'self'");
 
 require_once "inc_portal.php";
 

--- a/portal/contact_edit.php
+++ b/portal/contact_edit.php
@@ -4,7 +4,7 @@
  * Contact management for PTC / technical contacts
  */
 
-header("Content-Security-Policy: default-src 'self' fonts.googleapis.com fonts.gstatic.com");
+header("Content-Security-Policy: default-src 'self'");
 
 require_once "inc_portal.php";
 

--- a/portal/contacts.php
+++ b/portal/contacts.php
@@ -4,7 +4,7 @@
 * Contact management for PTC / technical contacts
 */
 
-header("Content-Security-Policy: default-src 'self' fonts.googleapis.com fonts.gstatic.com");
+header("Content-Security-Policy: default-src 'self'");
 
 require_once "inc_portal.php";
 

--- a/portal/document.php
+++ b/portal/document.php
@@ -4,7 +4,7 @@
  * Docs for PTC / technical contacts
  */
 
-header("Content-Security-Policy: default-src 'self' fonts.googleapis.com fonts.gstatic.com; img-src 'self' data:");
+header("Content-Security-Policy: default-src 'self'; img-src 'self' data:");
 
 require_once "inc_portal.php";
 

--- a/portal/documents.php
+++ b/portal/documents.php
@@ -4,7 +4,7 @@
  * Docs for PTC / technical contacts
  */
 
-header("Content-Security-Policy: default-src 'self' fonts.googleapis.com fonts.gstatic.com");
+header("Content-Security-Policy: default-src 'self'");
 
 require_once "inc_portal.php";
 

--- a/portal/domains.php
+++ b/portal/domains.php
@@ -4,7 +4,7 @@
 * Domain listing for PTC / technical contacts
 */
 
-header("Content-Security-Policy: default-src 'self' fonts.googleapis.com fonts.gstatic.com");
+header("Content-Security-Policy: default-src 'self'");
 
 require_once "inc_portal.php";
 

--- a/portal/index.php
+++ b/portal/index.php
@@ -4,7 +4,7 @@
  * Landing / Home page for the client portal
  */
 
-header("Content-Security-Policy: default-src 'self' fonts.googleapis.com fonts.gstatic.com");
+header("Content-Security-Policy: default-src 'self'");
 
 require_once "inc_portal.php";
 

--- a/portal/invoices.php
+++ b/portal/invoices.php
@@ -4,7 +4,7 @@
  * Invoices for PTC
  */
 
-header("Content-Security-Policy: default-src 'self' fonts.googleapis.com fonts.gstatic.com");
+header("Content-Security-Policy: default-src 'self'");
 
 require_once "inc_portal.php";
 

--- a/portal/login.php
+++ b/portal/login.php
@@ -4,7 +4,7 @@
  * Landing / Home page for the client portal
  */
 
-header("Content-Security-Policy: default-src 'self' fonts.googleapis.com fonts.gstatic.com");
+header("Content-Security-Policy: default-src 'self'");
 
 require_once '../config.php';
 
@@ -50,13 +50,13 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST' && isset($_POST['login'])) {
     $password = $_POST['password'];
 
     if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
-        
+
         header("HTTP/1.1 401 Unauthorized");
-        
+
         $_SESSION['login_message'] = 'Invalid e-mail';
-    
+
     } else {
-        
+
         $sql = mysqli_query($mysqli, "SELECT * FROM users LEFT JOIN contacts ON user_id = contact_user_id WHERE user_email = '$email' AND user_archived_at IS NULL AND user_type = 2 AND user_status = 1 LIMIT 1");
         $row = mysqli_fetch_array($sql);
         $client_id = intval($row['contact_client_id']);
@@ -82,7 +82,7 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST' && isset($_POST['login'])) {
                 logAction("Client Login", "Success", "Client contact $user_email successfully logged in locally", $client_id, $user_id);
 
             } else {
-                
+
                 // Logging
                 logAction("Client Login", "Failed", "Failed client portal login attempt using $email (incorrect password for contact ID $contact_id)", $client_id, $user_id);
 
@@ -92,14 +92,14 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST' && isset($_POST['login'])) {
             }
 
         } else {
-            
+
             // Logging
             logAction("Client Login", "Failed", "Failed client portal login attempt using $email (invalid email/not allowed local auth)");
-            
+
             header("HTTP/1.1 401 Unauthorized");
-            
+
             $_SESSION['login_message'] = 'Incorrect username or password.';
-        
+
         }
     }
 }
@@ -127,8 +127,6 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST' && isset($_POST['login'])) {
         <!-- Theme style -->
         <link rel="stylesheet" href="../dist/css/adminlte.min.css">
 
-        <!-- Google Font: Source Sans Pro -->
-        <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700" rel="stylesheet">
     </head>
 
     <body class="hold-transition login-page">

--- a/portal/login_reset.php
+++ b/portal/login_reset.php
@@ -4,7 +4,7 @@
  * Password reset page
  */
 
-header("Content-Security-Policy: default-src 'self' fonts.googleapis.com fonts.gstatic.com");
+header("Content-Security-Policy: default-src 'self'");
 
 require_once '../config.php';
 require_once '../functions.php';
@@ -195,8 +195,6 @@ if ($_SERVER['REQUEST_METHOD'] == "POST") {
     <!-- Theme style -->
     <link rel="stylesheet" href="../dist/css/adminlte.min.css">
 
-    <!-- Google Font: Source Sans Pro -->
-    <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700" rel="stylesheet">
 </head>
 
 <body class="hold-transition login-page">

--- a/portal/portal_header.php
+++ b/portal/portal_header.php
@@ -29,8 +29,6 @@ header("X-Frame-Options: DENY"); // Legacy
     <!-- Theme style -->
     <link rel="stylesheet" href="../dist/css/adminlte.min.css">
 
-    <!-- Google Font: Source Sans Pro -->
-    <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700" rel="stylesheet">
 </head>
 
 <!-- Navbar -->

--- a/portal/profile.php
+++ b/portal/profile.php
@@ -4,7 +4,7 @@
  * User profile
  */
 
-header("Content-Security-Policy: default-src 'self' fonts.googleapis.com fonts.gstatic.com");
+header("Content-Security-Policy: default-src 'self'");
 
 require_once 'inc_portal.php';
 

--- a/portal/quotes.php
+++ b/portal/quotes.php
@@ -4,7 +4,7 @@
  * Quotes for PTC / billing contacts
  */
 
-header("Content-Security-Policy: default-src 'self' fonts.googleapis.com fonts.gstatic.com");
+header("Content-Security-Policy: default-src 'self'");
 
 require_once "inc_portal.php";
 

--- a/portal/tickets.php
+++ b/portal/tickets.php
@@ -4,7 +4,7 @@
  * Landing / Home page for the client portal
  */
 
-header("Content-Security-Policy: default-src 'self' fonts.googleapis.com fonts.gstatic.com");
+header("Content-Security-Policy: default-src 'self'");
 
 require_once "inc_portal.php";
 


### PR DESCRIPTION
Starting to dig into merging the login flows and I noticed that we're still calling Source Sans Pro direct from Google. In [global.css](https://github.com/itflow-org/itflow/blob/a2f0f392be0f27ef5bb857a68efee6558102d4ed/global.css#L7) we define Sans Serif as the global font, I see no reason why we should have a slightly different font just for the login page. 
It looks like it was originally added sometime around when the login page was styled after being built and just never updated ([here](https://github.com/itflow-org/itflow/blob/e5036253edf7bc15e170f43d739314b32a68f599/login.php#L93)?).

By removing this we can also remove all references to fonts.googleapis.com fonts.gstatic.com as part of our CSP effort (#1036).

![image](https://github.com/user-attachments/assets/485b5fa6-91da-4b50-a5cb-3531f63649c9)
