### PR TITLE
Bugfix: Asset interface DHCP vanishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to ITFlow will be documented in this file.
 ## 25.1
 - Moved cron/cli scripts to scripts subfolder - Old scripts remain in the root for now, but please update your cron configurations!
 - Bugfix: Ticket edit modal not showing multi-client/no-client projects
+- Bugfix: Asset interface losing DHCP setting
 
 ## 24.12
 

--- a/client_asset_interface_add_modal.php
+++ b/client_asset_interface_add_modal.php
@@ -35,12 +35,17 @@
                     </div>
 
                     <div class="form-group">
-                        <label>IP</label>
+                        <label>IP or DHCP</label>
                         <div class="input-group">
                             <div class="input-group-prepend">
                                 <span class="input-group-text"><i class="fa fa-fw fa-ethernet"></i></span>
                             </div>
                             <input type="text" class="form-control" name="ip" placeholder="IP Address" data-inputmask="'alias': 'ip'" data-mask>
+                            <div class="input-group-append">
+                                <div class="input-group-text">
+                                    <input type="checkbox" name="dhcp" value="1" title="Check to mark address as DHCP controlled">
+                                </div>
+                            </div>
                         </div>
                     </div>
 

--- a/client_asset_interface_edit_modal.php
+++ b/client_asset_interface_edit_modal.php
@@ -35,12 +35,17 @@
                     </div>
 
                     <div class="form-group">
-                        <label>IP</label>
+                        <label>IPv4 or DHCP</label>
                         <div class="input-group">
                             <div class="input-group-prepend">
                                 <span class="input-group-text"><i class="fa fa-fw fa-ethernet"></i></span>
                             </div>
                             <input type="text" class="form-control" name="ip" placeholder="IP Address" value="<?php echo $interface_ip; ?>" data-inputmask="'alias': 'ip'" data-mask>
+                            <div class="input-group-append">
+                                <div class="input-group-text">
+                                    <input type="checkbox" name="dhcp" value="1" title="Check to mark address as DHCP controlled" <?php if ($interface_ip == 'DHCP') { echo "checked"; } ?>>
+                                </div>
+                            </div>
                         </div>
                     </div>
 


### PR DESCRIPTION
Fixes a bug that removes the DHCP setting on asset interfaces when changing their network interface from the asset details page