### PR TITLE
Update folder_create_modal.php

### DIFF
--- a/modals/folder_create_modal.php
+++ b/modals/folder_create_modal.php
@@ -2,7 +2,7 @@
     <div class="modal-dialog">
         <div class="modal-content bg-dark">
             <div class="modal-header">
-                <h5 class="modal-title"><i class="fa fa-fw fa-folder-plus mr-2"></i>Creating folder in <strong><?php if($get_folder_id > 0) { echo $folder['folder_name']; } else { echo "/"; } ?></strong></h5>
+                <h5 class="modal-title"><i class="fa fa-fw fa-folder-plus mr-2"></i>Creating folder in <strong><?php if($get_folder_id > 0) { echo $folder_path[count($folder_path)-1]['folder_name']; } else { echo "/"; } ?></strong></h5>
                 <button type="button" class="close text-white" data-dismiss="modal">
                     <span>&times;</span>
                 </button>


### PR DESCRIPTION
$folder['folder_name']; did not exist in the scope of where folder_create_modal.php was being required in the client_files.php and client_documents.php leading to null array pointer exception. While dirty the new way will reliably retrieve the name of the current folder the user is browsing and correctly name the modal.

![image](https://github.com/user-attachments/assets/56d788f2-f2c5-458c-944b-7b9693247b8a)

![image](https://github.com/user-attachments/assets/071863fb-10e1-47bb-9b17-e4941c444460)
