### PR TITLE
Recurring items with next-run dates in the past

### DIFF
--- a/post/user/ticket.php
+++ b/post/user/ticket.php
@@ -2260,7 +2260,7 @@ if (isset($_POST['bulk_delete_recurring_tickets'])) {
         $count = count($_POST['recurring_ticket_ids']);
 
         // Cycle through array and delete each recurring scheduled ticket
-        foreach ($recurring_ticket_ids as $recurring_ticket_id) {
+        foreach ($_POST['recurring_ticket_ids'] as $recurring_ticket_id) {
 
             $recurring_ticket_id = intval($recurring_ticket_id);
             mysqli_query($mysqli, "DELETE FROM recurring_tickets WHERE recurring_ticket_id = $recurring_ticket_id");


### PR DESCRIPTION
Notify if a recurring ticket, invoice or expense has a next run date in the past - it needs to be manually adjusted for cron to pick it up again.
Also, bugfix bulk recurring ticket delete.