### PR TITLE
Fix Dashboard following DB Update 1.9.7

### DIFF
--- a/ajax/ajax_trip_copy.php
+++ b/ajax/ajax_trip_copy.php
@@ -115,7 +115,7 @@ ob_start();
 
                     $sql_users = mysqli_query($mysqli, "SELECT users.user_id, user_name FROM users
                         LEFT JOIN user_settings on users.user_id = user_settings.user_id
-                        WHERE user_role > 1 AND user_archived_at IS NULL ORDER BY user_name ASC"
+                        WHERE user_role_id > 1 AND user_archived_at IS NULL ORDER BY user_name ASC"
                     );
                     while ($row = mysqli_fetch_array($sql_users)) {
                         $user_id_select = intval($row['user_id']);

--- a/dashboard.php
+++ b/dashboard.php
@@ -151,7 +151,7 @@ if ($user_config_dashboard_financial_enable == 1) {
         $row = mysqli_fetch_array($sql_unbilled_tickets);
         $unbilled_tickets = intval($row['unbilled_tickets']);
     } else {
-        $row = mysqli_fetch_assoc(mysqli_query($mysqli, "SELECT COUNT(recurring_id) AS recurring_invoices_added FROM recurring WHERE YEAR(recurring_created_at) = $year"));
+        $row = mysqli_fetch_assoc(mysqli_query($mysqli, "SELECT COUNT(recurring_invoice_id) AS recurring_invoices_added FROM recurring_invoices WHERE YEAR(recurring_invoice_created_at) = $year"));
         $recurring_invoices_added = intval($row['recurring_invoices_added']);
     }
 


### PR DESCRIPTION
The `dashboard.php` file was still using old table names prior to DB version 1.9.7 - `recurring` instead of `recurring_invoices`. This meant the financial dashboard was not loading up correctly and an unhandled exception was thrown.

This commit fixes this and ensures the financial dashboard is displayed correctly.